### PR TITLE
Parse and visualise security scheme. Closes #69

### DIFF
--- a/docs/open-api-v3-support.md
+++ b/docs/open-api-v3-support.md
@@ -29,7 +29,7 @@ This document outlines this project's support for visualising the [Open API V3][
 - [ ] [servers](#servers-object)
 - [x] [paths](#paths-object)
 - [ ] [components](#components-object)
-- [ ] [security](#security-requirement-object)
+- [x] [security](#security-requirement-object)
 - [ ] [tags](#tag-object)
 - [ ] [externalDocs](#external-documentation-object)
 
@@ -97,16 +97,16 @@ This is supported by default as all `$ref` are dereferenced before the definitio
 - [x] [patch](#operation-object)
 - [x] [trace](#operation-object)
 - [ ] [server](#server-object)
-- [x] [parameters](#parameter-object)
+- [ ] [parameters](#parameter-object)
 
 ### [Operation](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#operation-object) object
 
 - [x] tags - Currently *required* for this project.
-- [ ] summary
+- [x] summary
 - [x] description
 - [ ] [externalDocs](#external-documentation-object)
 - [ ] operationId
-- [ ] [parameters](#parameter-object)
+- [x] [parameters](#parameter-object)
 - [x] [requestBody](#request-body-object)
 - [x] [responses](#responses-object)
 - [ ] [callbacks](#callback-object)
@@ -282,33 +282,37 @@ The OpenAPI specification also supports several additional properties from JSON 
 
 ### [Security Scheme](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#security-scheme-object) object
 
-- [ ] type
-- [ ] description
-- [ ] name
-- [ ] in
-- [ ] scheme
-- [ ] bearerFormat
-- [ ] [flows](#oauth-flows-object)
-- [ ] openIdConnectUrl
+- [x] type
+  - [x] apiKey
+  - [x] http
+  - [x] oauth2
+  - [x] openIdConnect
+- [x] description
+- [x] name
+- [x] in
+- [x] scheme
+- [x] bearerFormat
+- [x] [flows](#oauth-flows-object)
+- [x] openIdConnectUrl
 
 ### [OAuth Flows](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#oauth-flows-object) object
 
-- [ ] [implict](#oauth-flow-object)
-- [ ] [password](#oauth-flow-object)
-- [ ] [clientCredentials](#oauth-flow-object)
-- [ ] [authorizationCode](#oauth-flow-object)
+- [x] [implict](#oauth-flow-object)
+- [x] [password](#oauth-flow-object)
+- [x] [clientCredentials](#oauth-flow-object)
+- [x] [authorizationCode](#oauth-flow-object)
 
 ### [OAuth Flow](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#oauth-flow-object) object
 
-- [ ] authorizationUrl
-- [ ] tokenUrl
-- [ ] refreshUrl
-- [ ] scopes
+- [x] authorizationUrl
+- [x] tokenUrl
+- [x] refreshUrl
+- [x] scopes
 
 ### [Security Requirement](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#security-requirement-object) object
 
-- [ ] oauth2
-- [ ] openIdConnect
+- [x] oauth2
+- [x] openIdConnect
 - [ ] "other"
 
 ### [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#specification-extensions)

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -16,7 +16,7 @@ export default class Header extends PureComponent {
         <div>
           <DownloadButton url={specUrl}>Download this Open API definition.</DownloadButton>
         </div>
-        <dl>
+        <dl className='inline-pairs'>
           <dt>Version</dt>
           <dd>{version}</dd>
         </dl>

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -2,28 +2,4 @@
 
 header {
   padding: 0 20px;
-
-  dl {
-    float: left;
-    margin: 1em 0;
-    padding: 0;
-    border-bottom: 1px solid $border-color;
-  }
-
-  dt {
-    clear: left;
-    float: left;
-    width: 100px;
-    margin: 0;
-    padding: 5px;
-    border-top: 1px solid $border-color;
-    font-weight: bold;
-  }
-
-  dd {
-    float: left;
-    margin: 0;
-    padding: 5px;
-    border-top: 1px solid $border-color;
-  }
 }

--- a/src/components/Method/Method.scss
+++ b/src/components/Method/Method.scss
@@ -1,16 +1,7 @@
 @import '../../base.scss';
 
 .method {
-  padding: 10px;
   border: 1px solid $border-color;
-  margin-bottom: 30px;
-  margin-left: 10px;
-
-  .method-body {
-    margin-left: 20px;
-  }
-}
-
-h3 {
-  margin: 0;
+  margin: 0 1rem 2rem 0;
+  padding: 1rem;
 }

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import Header from '../Header/Header'
 import Navigation from '../Navigation/Navigation'
 import ContentContainer from '../ContentContainer/ContentContainer'
+import SecurityContainer from '../SecurityContainer/SecurityContainer'
 import ServiceContainer from '../ServiceContainer/ServiceContainer'
 
 import './Page.scss'
@@ -16,7 +17,7 @@ export default class Page extends Component {
       return null
     }
 
-    const { navigation, services } = definition
+    const { navigation, services, security } = definition
 
     return (
       <div className='page'>
@@ -28,20 +29,35 @@ export default class Page extends Component {
             version={definition.version}
             specUrl={specUrl}
           />
+          {security && this.renderSecurity(security)}
           <ContentContainer>
             {services && services.map(
-              (service) =>
-                <ServiceContainer key={service.title} service={service} />
+              (service) => <ServiceContainer key={service.title} service={service} />
             )}
           </ContentContainer>
         </div>
       </div>
     )
   }
+
+  renderSecurity (security) {
+    return (
+      <ContentContainer>
+        <h2>Authentication</h2>
+        {Object.keys(security).map(
+          (id) => <SecurityContainer key={id} id={id} security={security[id]} />
+        )}
+      </ContentContainer>
+    )
+  }
 }
 
 Page.propTypes = {
-  definition: PropTypes.object,
+  definition: PropTypes.shape({
+    navigation: PropTypes.arrayOf(PropTypes.object),
+    services: PropTypes.arrayOf(PropTypes.object),
+    security: PropTypes.object
+  }),
   location: PropTypes.object,
   specUrl: PropTypes.string
 }

--- a/src/components/SecurityContainer/SecurityContainer.js
+++ b/src/components/SecurityContainer/SecurityContainer.js
@@ -1,0 +1,108 @@
+import React, { PureComponent } from 'react'
+import PropTypes from 'prop-types'
+
+import Description from '../Description/Description'
+
+import './SecurityContainer.scss'
+
+export default class SecurityContainer extends PureComponent {
+  render () {
+    const { id, security } = this.props
+    const isSimple = ['apiKey', 'http'].includes(security.type)
+
+    return (
+      <section className='security-container' id={id}>
+        {isSimple && this.renderSimple(security)}
+        {security.type === 'oauth2' && this.renderOAuth2(security)}
+        {security.type === 'openIdConnect' && this.renderOpenIdConnect(security)}
+      </section>
+    )
+  }
+
+  renderSimple (security) {
+    const { name, type, description, example, bearerFormat } = security
+    let usage
+
+    if (security.in === 'query') {
+      usage = <p>To use this authentication scheme, add <code>{example}</code> to request URLs.</p>
+    } else {
+      usage = <p>To use this authentication scheme, pass <code>{example}</code>{bearerFormat ? `, formatted as ${bearerFormat}` : ''} as a request header.</p>
+    }
+
+    return (
+      <div>
+        <h3>{name} <code className='scheme'>type={type}</code></h3>
+        {description && <Description description={description} />}
+        {usage}
+      </div>
+    )
+  }
+
+  renderOAuth2 (security) {
+    const { name, type, description, flows } = security
+
+    return (
+      <div>
+        <h3>{name} <code className='scheme'>type={type}</code></h3>
+        {description && <Description description={description} />}
+        {Object.keys(flows).map((flowKey) => {
+          const flow = flows[flowKey]
+
+          return (
+            <div className='flow-type' key={flowKey}>
+              <h4><code>{flowKey}</code> flow</h4>
+              <dl className='inline-pairs'>
+                {flow.authorizationUrl && [
+                  <dt key='auth'>Authorization URL</dt>,
+                  <dd key='auth-value'>{flow.authorizationUrl}</dd>
+                ]}
+                {flow.tokenUrl && [
+                  <dt key='token'>Token URL</dt>,
+                  <dd key='token-value'>{flow.tokenUrl}</dd>
+                ]}
+                {flow.refreshUrl && [
+                  <dt key='refresh'>Refresh URL</dt>,
+                  <dd key='refresh-value'>{flow.refreshUrl}</dd>
+                ]}
+              </dl>
+              <div className='scopes'>
+                <h5>Available scopes</h5>
+                {this.renderScopes(flow.scopes)}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+
+  renderScopes (scopes) {
+    return (
+      <ul>
+        {Object.keys(scopes).map(
+          (scope) => <li key={scope}><strong>{scope}</strong> {scopes[scope]}</li>)
+        }
+      </ul>
+    )
+  }
+
+  renderOpenIdConnect (security) {
+    const { name, type, description, openIdConnectUrl } = security
+
+    return (
+      <div>
+        <h3>{name} <code className='scheme'>type={type}</code></h3>
+        {description && <Description description={description} />}
+        <dl className='inline-pairs'>
+          <dt>OpenID Connect URL</dt>
+          <dd>{openIdConnectUrl}</dd>
+        </dl>
+      </div>
+    )
+  }
+}
+
+SecurityContainer.propTypes = {
+  id: PropTypes.string,
+  security: PropTypes.object
+}

--- a/src/components/SecurityContainer/SecurityContainer.js
+++ b/src/components/SecurityContainer/SecurityContainer.js
@@ -8,10 +8,13 @@ import './SecurityContainer.scss'
 export default class SecurityContainer extends PureComponent {
   render () {
     const { id, security } = this.props
+    const { name, type, description } = security
     const isSimple = ['apiKey', 'http'].includes(security.type)
 
     return (
       <section className='security-container' id={id}>
+        <h3>{name} <code className='scheme'>type={type}</code></h3>
+        {description && <Description description={description} />}
         {isSimple && this.renderSimple(security)}
         {security.type === 'oauth2' && this.renderOAuth2(security)}
         {security.type === 'openIdConnect' && this.renderOpenIdConnect(security)}
@@ -20,7 +23,7 @@ export default class SecurityContainer extends PureComponent {
   }
 
   renderSimple (security) {
-    const { name, type, description, example, bearerFormat } = security
+    const { example, bearerFormat } = security
     let usage
 
     if (security.in === 'query') {
@@ -31,20 +34,16 @@ export default class SecurityContainer extends PureComponent {
 
     return (
       <div>
-        <h3>{name} <code className='scheme'>type={type}</code></h3>
-        {description && <Description description={description} />}
         {usage}
       </div>
     )
   }
 
   renderOAuth2 (security) {
-    const { name, type, description, flows } = security
+    const { flows } = security
 
     return (
       <div>
-        <h3>{name} <code className='scheme'>type={type}</code></h3>
-        {description && <Description description={description} />}
         {Object.keys(flows).map((flowKey) => {
           const flow = flows[flowKey]
 
@@ -87,12 +86,10 @@ export default class SecurityContainer extends PureComponent {
   }
 
   renderOpenIdConnect (security) {
-    const { name, type, description, openIdConnectUrl } = security
+    const { openIdConnectUrl } = security
 
     return (
       <div>
-        <h3>{name} <code className='scheme'>type={type}</code></h3>
-        {description && <Description description={description} />}
         <dl className='inline-pairs'>
           <dt>OpenID Connect URL</dt>
           <dd>{openIdConnectUrl}</dd>

--- a/src/components/SecurityContainer/SecurityContainer.scss
+++ b/src/components/SecurityContainer/SecurityContainer.scss
@@ -1,0 +1,26 @@
+@import '../../base.scss';
+
+.security-container {
+  padding: 1rem 0;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid $border-color;
+
+  .scheme {
+    display: inline-block;
+    padding: .4rem;
+    margin-left: .5rem;
+    background-color: $navigation-background;
+  }
+
+  .flow-type {
+    padding: 1rem 0;
+
+    & + .flow-type {
+      border-bottom: 1px dotted $border-color
+    }
+  }
+
+  h3 {
+    margin-bottom: .5rem;
+  }
+}

--- a/src/components/SecurityContainer/SecurityContainer.scss
+++ b/src/components/SecurityContainer/SecurityContainer.scss
@@ -16,11 +16,7 @@
     padding: 1rem 0;
 
     & + .flow-type {
-      border-bottom: 1px dotted $border-color
+      border-top: 1px dotted $border-color
     }
-  }
-
-  h3 {
-    margin-bottom: .5rem;
   }
 }

--- a/src/components/ServiceContainer/ServiceContainer.scss
+++ b/src/components/ServiceContainer/ServiceContainer.scss
@@ -1,4 +1,3 @@
 .service-container {
-  clear: left;
-  padding-top: 20px;
+  padding-top: 2rem;
 }

--- a/src/general.scss
+++ b/src/general.scss
@@ -9,7 +9,21 @@ body {
   margin: 0;
   padding: 0;
   font-family: $body-font;
+  line-height: 1.4;
   color: white;
+}
+
+ul, ol {
+  margin: .5rem 0;
+  padding: 0
+
+  li {
+    margin-left: 1.5rem;
+  }
+}
+
+h3, h4, h5, h6 {
+  margin: 0;
 }
 
 a {
@@ -21,4 +35,24 @@ a {
     color: lighten($link-color, 20%);
     text-decoration: underline;
   }
+}
+
+.inline-pairs {
+  display: inline-flex;
+  margin: 1em 0;
+  padding: 0;
+  border-bottom: 1px solid $border-color;
+}
+
+.inline-pairs dt,
+.inline-pairs dd {
+  margin: 0;
+  padding: .5rem;
+  border-top: 1px solid $border-color;
+}
+
+.inline-pairs dt {
+  min-width: 5rem;
+  padding-right: 1.5rem;
+  font-weight: bold;
 }

--- a/src/parser/open-api/v3/open-api-v3-parser.js
+++ b/src/parser/open-api/v3/open-api-v3-parser.js
@@ -1,5 +1,5 @@
 import refParser from 'json-schema-ref-parser'
-import { getSecurity, getUISecurity } from './securityParser'
+import { getSecurityDefinitions, getUISecurity } from './securityParser'
 import getUIReadySchema from '../schemaParser'
 import { sortByUIMethod } from '../../sorting'
 
@@ -8,7 +8,7 @@ import { sortByUIMethod } from '../../sorting'
  *
  * @param {Array} tags
  * @param {Object} paths
- * @param {Object} globalSecurity
+ * @param {Array} globalSecurity
  * @param {Object} securityDefinitions
  * @return {{navigation: [], services: []}}
  */
@@ -306,8 +306,8 @@ export default async function getUIReadyDefinition (openApiV3) {
   // Get tags
   const tags = getTags(paths)
 
-  // Get security schemes
-  const security = getSecurity(derefOpenApiV3)
+  // Get security definitions
+  const security = getSecurityDefinitions(derefOpenApiV3)
 
   // Construction navigation and services
   const {navigation, services} = getUINavigationAndServices(tags, paths, derefOpenApiV3.security || [], security)

--- a/src/parser/open-api/v3/securityParser.js
+++ b/src/parser/open-api/v3/securityParser.js
@@ -7,7 +7,7 @@
  * @param {Object} definition
  * @return {Object}
  */
-export function getSecurity (definition) {
+export function getSecurityDefinitions (definition) {
   let securityDefinitions = {}
 
   if (definition.components && definition.components.securitySchemes) {

--- a/src/parser/open-api/v3/securityParser.js
+++ b/src/parser/open-api/v3/securityParser.js
@@ -1,0 +1,66 @@
+/**
+ * Extracts any security schemes from the given Open API V3 definition file.
+ * Security schemes are defined in `components.securitySchemes`.
+ * The API defines what security applies at either the top level (`security`)
+ * or per operation.
+ *
+ * @param {Object} definition
+ * @return {Object}
+ */
+export function getSecurity (definition) {
+  let securityDefinitions = {}
+
+  if (definition.components && definition.components.securitySchemes) {
+    securityDefinitions = { ...definition.components.securitySchemes }
+  }
+
+  // Always set a name.
+  Object.keys(securityDefinitions).forEach((key) => {
+    const scheme = securityDefinitions[key]
+    let example
+
+    if (!scheme.name) {
+      scheme.name = key
+    }
+
+    if (scheme.type === 'http') {
+      example = `Authorization: ${scheme.scheme} credentials`
+    } else if (scheme.type === 'apiKey') {
+      if (scheme.in === 'query') {
+        example = `?${scheme.name}=credentials`
+      } else {
+        example = `${scheme.name}: credentials`
+      }
+    }
+
+    if (example) {
+      scheme.example = example
+    }
+  })
+
+  return securityDefinitions
+}
+
+/**
+ * Simplifies the security definition for operation objects by merging the
+ * global definition in.
+ *
+ * @param {Array} security
+ * @param {Object} definitions
+ * @return {Object}
+ */
+export function getUISecurity (security, definitions) {
+  return security.reduce((prev, curr) => {
+    const name = Object.keys(curr)[0]
+    const definition = { ...definitions[name] }
+
+    // If this definition is OAuth2/OpenIdConnect, add the applicable scopes.
+    if (['oauth2', 'openIdConnect'].includes(definition.type) && curr[name].length) {
+      definition.applicableScopes = curr[name]
+    }
+
+    prev[name] = definition
+
+    return prev
+  }, {})
+}

--- a/test/components/SecurityContainer.test.js
+++ b/test/components/SecurityContainer.test.js
@@ -1,0 +1,80 @@
+import React from 'react'
+import SecurityContainer from './../../src/components/SecurityContainer/SecurityContainer'
+import renderer from 'react-test-renderer'
+
+describe('<SecurityContainer />', () => {
+  it('renders apiKey type', () => {
+    const security = {
+      type: 'apiKey',
+      name: 'api_key',
+      in: 'header',
+      example: 'api_key: credentials'
+    }
+
+    const tree = renderer.create(
+      <SecurityContainer id='api_key' security={security} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders http type', () => {
+    const security = {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+      name: 'JWT',
+      example: 'Authorization: bearer credentials'
+    }
+
+    const tree = renderer.create(
+      <SecurityContainer id='JWT' security={security} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders oauth2 type', () => {
+    const security = {
+      name: 'oauth2',
+      type: 'oauth2',
+      flows: {
+        implicit: {
+          authorizationUrl: 'https://example.com/api/oauth/dialog',
+          scopes: {
+            'write:pets': 'modify pets in your account',
+            'read:pets': 'read your pets'
+          }
+        },
+        authorizationCode: {
+          authorizationUrl: 'https://example.com/api/oauth/dialog',
+          tokenUrl: 'https://example.com/api/oauth/token',
+          scopes: {
+            'write:pets': 'modify pets in your account',
+            'read:pets': 'read your pets'
+          }
+        }
+      }
+    }
+
+    const tree = renderer.create(
+      <SecurityContainer id='oauth2' security={security} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders openIdConnect type', () => {
+    const security = {
+      name: 'openIdConnect',
+      type: 'openIdConnect',
+      openIdConnect: 'https://example.com/openIdConnect'
+    }
+
+    const tree = renderer.create(
+      <SecurityContainer id='openIdConnect' security={security} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/components/__snapshots__/SecurityContainer.test.js.snap
+++ b/test/components/__snapshots__/SecurityContainer.test.js.snap
@@ -5,17 +5,17 @@ exports[`<SecurityContainer /> renders apiKey type 1`] = `
   className="security-container"
   id="api_key"
 >
+  <h3>
+    api_key
+     
+    <code
+      className="scheme"
+    >
+      type=
+      apiKey
+    </code>
+  </h3>
   <div>
-    <h3>
-      api_key
-       
-      <code
-        className="scheme"
-      >
-        type=
-        apiKey
-      </code>
-    </h3>
     <p>
       To use this authentication scheme, pass 
       <code>
@@ -33,17 +33,17 @@ exports[`<SecurityContainer /> renders http type 1`] = `
   className="security-container"
   id="JWT"
 >
+  <h3>
+    JWT
+     
+    <code
+      className="scheme"
+    >
+      type=
+      http
+    </code>
+  </h3>
   <div>
-    <h3>
-      JWT
-       
-      <code
-        className="scheme"
-      >
-        type=
-        http
-      </code>
-    </h3>
     <p>
       To use this authentication scheme, pass 
       <code>
@@ -61,17 +61,17 @@ exports[`<SecurityContainer /> renders oauth2 type 1`] = `
   className="security-container"
   id="oauth2"
 >
-  <div>
-    <h3>
+  <h3>
+    oauth2
+     
+    <code
+      className="scheme"
+    >
+      type=
       oauth2
-       
-      <code
-        className="scheme"
-      >
-        type=
-        oauth2
-      </code>
-    </h3>
+    </code>
+  </h3>
+  <div>
     <div
       className="flow-type"
     >
@@ -173,17 +173,17 @@ exports[`<SecurityContainer /> renders openIdConnect type 1`] = `
   className="security-container"
   id="openIdConnect"
 >
-  <div>
-    <h3>
+  <h3>
+    openIdConnect
+     
+    <code
+      className="scheme"
+    >
+      type=
       openIdConnect
-       
-      <code
-        className="scheme"
-      >
-        type=
-        openIdConnect
-      </code>
-    </h3>
+    </code>
+  </h3>
+  <div>
     <dl
       className="inline-pairs"
     >

--- a/test/components/__snapshots__/SecurityContainer.test.js.snap
+++ b/test/components/__snapshots__/SecurityContainer.test.js.snap
@@ -1,0 +1,197 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SecurityContainer /> renders apiKey type 1`] = `
+<section
+  className="security-container"
+  id="api_key"
+>
+  <div>
+    <h3>
+      api_key
+       
+      <code
+        className="scheme"
+      >
+        type=
+        apiKey
+      </code>
+    </h3>
+    <p>
+      To use this authentication scheme, pass 
+      <code>
+        api_key: credentials
+      </code>
+      
+       as a request header.
+    </p>
+  </div>
+</section>
+`;
+
+exports[`<SecurityContainer /> renders http type 1`] = `
+<section
+  className="security-container"
+  id="JWT"
+>
+  <div>
+    <h3>
+      JWT
+       
+      <code
+        className="scheme"
+      >
+        type=
+        http
+      </code>
+    </h3>
+    <p>
+      To use this authentication scheme, pass 
+      <code>
+        Authorization: bearer credentials
+      </code>
+      , formatted as JWT
+       as a request header.
+    </p>
+  </div>
+</section>
+`;
+
+exports[`<SecurityContainer /> renders oauth2 type 1`] = `
+<section
+  className="security-container"
+  id="oauth2"
+>
+  <div>
+    <h3>
+      oauth2
+       
+      <code
+        className="scheme"
+      >
+        type=
+        oauth2
+      </code>
+    </h3>
+    <div
+      className="flow-type"
+    >
+      <h4>
+        <code>
+          implicit
+        </code>
+         flow
+      </h4>
+      <dl
+        className="inline-pairs"
+      >
+        <dt>
+          Authorization URL
+        </dt>
+        <dd>
+          https://example.com/api/oauth/dialog
+        </dd>
+      </dl>
+      <div
+        className="scopes"
+      >
+        <h5>
+          Available scopes
+        </h5>
+        <ul>
+          <li>
+            <strong>
+              write:pets
+            </strong>
+             
+            modify pets in your account
+          </li>
+          <li>
+            <strong>
+              read:pets
+            </strong>
+             
+            read your pets
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      className="flow-type"
+    >
+      <h4>
+        <code>
+          authorizationCode
+        </code>
+         flow
+      </h4>
+      <dl
+        className="inline-pairs"
+      >
+        <dt>
+          Authorization URL
+        </dt>
+        <dd>
+          https://example.com/api/oauth/dialog
+        </dd>
+        <dt>
+          Token URL
+        </dt>
+        <dd>
+          https://example.com/api/oauth/token
+        </dd>
+      </dl>
+      <div
+        className="scopes"
+      >
+        <h5>
+          Available scopes
+        </h5>
+        <ul>
+          <li>
+            <strong>
+              write:pets
+            </strong>
+             
+            modify pets in your account
+          </li>
+          <li>
+            <strong>
+              read:pets
+            </strong>
+             
+            read your pets
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`<SecurityContainer /> renders openIdConnect type 1`] = `
+<section
+  className="security-container"
+  id="openIdConnect"
+>
+  <div>
+    <h3>
+      openIdConnect
+       
+      <code
+        className="scheme"
+      >
+        type=
+        openIdConnect
+      </code>
+    </h3>
+    <dl
+      className="inline-pairs"
+    >
+      <dt>
+        OpenID Connect URL
+      </dt>
+      <dd />
+    </dl>
+  </div>
+</section>
+`;

--- a/test/parser/open-api/v3/data/inputs/petstore.json
+++ b/test/parser/open-api/v3/data/inputs/petstore.json
@@ -1,0 +1,1072 @@
+{
+  "openapi": "3.0.0-RC1",
+  "servers": [
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "x-origin": [
+    {
+      "url": "http://petstore.swagger.io/v2/swagger.json",
+      "format": "swagger",
+      "version": "2.0",
+      "converter": {
+        "url": "https://github.com/mermade/swagger2openapi",
+        "version": "1.2.1"
+      }
+    }
+  ],
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "parameters": [],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/requestBody1"
+        }
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "parameters": [],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/requestBody1"
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "pending",
+                  "sold"
+                ],
+                "default": "available"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "deprecated": true
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "Updated name of the pet",
+                    "type": "string",
+                    "required": false
+                  },
+                  "status": {
+                    "description": "Updated status of the pet",
+                    "type": "string",
+                    "required": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "order placed for purchasing the pet",
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Created user object",
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/requestBody2"
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/requestBody2"
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "password"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be updated",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Updated user object",
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "petId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ]
+          },
+          "complete": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "xml": {
+          "name": "Order"
+        }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Category"
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "username": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "userStatus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "User Status"
+          }
+        },
+        "xml": {
+          "name": "User"
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Tag"
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "name": "photoUrl",
+              "wrapped": true
+            },
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "name": "tag",
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "Pet"
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "responses": {},
+    "parameters": {},
+    "examples": {},
+    "requestBodies": {
+      "requestBody1": {
+        "content": {
+          "application/json": {
+            "description": "Pet object that needs to be added to the store",
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "application/xml": {
+            "description": "Pet object that needs to be added to the store",
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      },
+      "requestBody2": {
+        "content": {
+          "application/json": {
+            "description": "List of user object",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    },
+    "headers": {}
+  }
+}

--- a/test/parser/open-api/v3/data/outputs/accounts.json
+++ b/test/parser/open-api/v3/data/outputs/accounts.json
@@ -19,6 +19,7 @@
       ]
     }
   ],
+  "security": {},
   "services": [
     {
       "title": "Account",

--- a/test/parser/open-api/v3/data/outputs/carrier.json
+++ b/test/parser/open-api/v3/data/outputs/carrier.json
@@ -14,6 +14,7 @@
       ]
     }
   ],
+  "security": {},
   "services": [
     {
       "title": "Carriers",

--- a/test/parser/open-api/v3/data/outputs/petstore.json
+++ b/test/parser/open-api/v3/data/outputs/petstore.json
@@ -1,0 +1,1857 @@
+{
+  "title": "Swagger Petstore",
+  "version": "1.0.0",
+  "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+  "navigation": [
+    {
+      "title": "pet",
+      "methods": [
+        {
+          "type": "get",
+          "title": "Find pet by ID",
+          "link": "/pet/{petId}/get"
+        },
+        {
+          "type": "get",
+          "title": "Finds Pets by status",
+          "link": "/pet/findByStatus/get"
+        },
+        {
+          "type": "get",
+          "title": "Finds Pets by tags",
+          "link": "/pet/findByTags/get"
+        },
+        {
+          "type": "post",
+          "title": "Add a new pet to the store",
+          "link": "/pet/post"
+        },
+        {
+          "type": "post",
+          "title": "Updates a pet in the store with form data",
+          "link": "/pet/{petId}/post"
+        },
+        {
+          "type": "post",
+          "title": "uploads an image",
+          "link": "/pet/{petId}/uploadImage/post"
+        },
+        {
+          "type": "put",
+          "title": "Update an existing pet",
+          "link": "/pet/put"
+        },
+        {
+          "type": "delete",
+          "title": "Deletes a pet",
+          "link": "/pet/{petId}/delete"
+        }
+      ]
+    },
+    {
+      "title": "store",
+      "methods": [
+        {
+          "type": "get",
+          "title": "Find purchase order by ID",
+          "link": "/store/order/{orderId}/get"
+        },
+        {
+          "type": "get",
+          "title": "Returns pet inventories by status",
+          "link": "/store/inventory/get"
+        },
+        {
+          "type": "post",
+          "title": "Place an order for a pet",
+          "link": "/store/order/post"
+        },
+        {
+          "type": "delete",
+          "title": "Delete purchase order by ID",
+          "link": "/store/order/{orderId}/delete"
+        }
+      ]
+    },
+    {
+      "title": "user",
+      "methods": [
+        {
+          "type": "get",
+          "title": "Get user by user name",
+          "link": "/user/{username}/get"
+        },
+        {
+          "type": "get",
+          "title": "Logs out current logged in user session",
+          "link": "/user/logout/get"
+        },
+        {
+          "type": "get",
+          "title": "Logs user into the system",
+          "link": "/user/login/get"
+        },
+        {
+          "type": "post",
+          "title": "Create user",
+          "link": "/user/post"
+        },
+        {
+          "type": "post",
+          "title": "Creates list of users with given input array",
+          "link": "/user/createWithArray/post"
+        },
+        {
+          "type": "post",
+          "title": "Creates list of users with given input array",
+          "link": "/user/createWithList/post"
+        },
+        {
+          "type": "put",
+          "title": "Updated user",
+          "link": "/user/{username}/put"
+        },
+        {
+          "type": "delete",
+          "title": "Delete user",
+          "link": "/user/{username}/delete"
+        }
+      ]
+    }
+  ],
+  "services": [
+    {
+      "title": "pet",
+      "methods": [
+        {
+          "type": "get",
+          "title": "Find pet by ID",
+          "link": "/pet/{petId}/get",
+          "request": {
+            "description": "Returns a single pet"
+          },
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation",
+              "schema": [
+                {
+                  "name": "id",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int64"
+                  }
+                },
+                {
+                  "name": "category",
+                  "type": [
+                    "object"
+                  ],
+                  "required": false,
+                  "properties": [
+                    {
+                      "name": "id",
+                      "type": [
+                        "integer"
+                      ],
+                      "required": false,
+                      "constraints": {
+                        "format": "int64"
+                      }
+                    },
+                    {
+                      "name": "name",
+                      "type": [
+                        "string"
+                      ],
+                      "required": false
+                    }
+                  ]
+                },
+                {
+                  "name": "name",
+                  "type": [
+                    "string"
+                  ],
+                  "required": true
+                },
+                {
+                  "name": "photoUrls",
+                  "type": [
+                    "array"
+                  ],
+                  "required": true,
+                  "subtype": "string"
+                },
+                {
+                  "name": "tags",
+                  "type": [
+                    "array"
+                  ],
+                  "required": false,
+                  "properties": [
+                    {
+                      "name": "id",
+                      "type": [
+                        "integer"
+                      ],
+                      "required": false,
+                      "constraints": {
+                        "format": "int64"
+                      }
+                    },
+                    {
+                      "name": "name",
+                      "type": [
+                        "string"
+                      ],
+                      "required": false
+                    }
+                  ]
+                },
+                {
+                  "name": "status",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false,
+                  "description": "pet status in the store",
+                  "enum": [
+                    "available",
+                    "pending",
+                    "sold"
+                  ]
+                }
+              ]
+            },
+            {
+              "code": "400",
+              "description": "Invalid ID supplied"
+            },
+            {
+              "code": "404",
+              "description": "Pet not found"
+            }
+          ],
+          "description": "Returns a single pet",
+          "security": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "api_key",
+              "in": "header",
+              "example": "api_key: credentials"
+            }
+          },
+          "parameters": {
+            "path": [
+              {
+                "name": "petId",
+                "description": "ID of pet to return",
+                "required": true,
+                "type": [
+                  "integer"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "get",
+          "title": "Finds Pets by status",
+          "link": "/pet/findByStatus/get",
+          "request": {
+            "description": "Multiple status values can be provided with comma separated strings"
+          },
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation",
+              "schema": [
+                {
+                  "name": "",
+                  "type": [
+                    "array"
+                  ],
+                  "required": false,
+                  "properties": [
+                    {
+                      "name": "id",
+                      "type": [
+                        "integer"
+                      ],
+                      "required": false,
+                      "constraints": {
+                        "format": "int64"
+                      }
+                    },
+                    {
+                      "name": "category",
+                      "type": [
+                        "object"
+                      ],
+                      "required": false,
+                      "properties": [
+                        {
+                          "name": "id",
+                          "type": [
+                            "integer"
+                          ],
+                          "required": false,
+                          "constraints": {
+                            "format": "int64"
+                          }
+                        },
+                        {
+                          "name": "name",
+                          "type": [
+                            "string"
+                          ],
+                          "required": false
+                        }
+                      ]
+                    },
+                    {
+                      "name": "name",
+                      "type": [
+                        "string"
+                      ],
+                      "required": true
+                    },
+                    {
+                      "name": "photoUrls",
+                      "type": [
+                        "array"
+                      ],
+                      "required": true,
+                      "subtype": "string"
+                    },
+                    {
+                      "name": "tags",
+                      "type": [
+                        "array"
+                      ],
+                      "required": false,
+                      "properties": [
+                        {
+                          "name": "id",
+                          "type": [
+                            "integer"
+                          ],
+                          "required": false,
+                          "constraints": {
+                            "format": "int64"
+                          }
+                        },
+                        {
+                          "name": "name",
+                          "type": [
+                            "string"
+                          ],
+                          "required": false
+                        }
+                      ]
+                    },
+                    {
+                      "name": "status",
+                      "type": [
+                        "string"
+                      ],
+                      "required": false,
+                      "description": "pet status in the store",
+                      "enum": [
+                        "available",
+                        "pending",
+                        "sold"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "code": "400",
+              "description": "Invalid status value"
+            }
+          ],
+          "description": "Multiple status values can be provided with comma separated strings",
+          "security": {
+            "petstore_auth": {
+              "name": "petstore_auth",
+              "type": "oauth2",
+              "flows": {
+                "implicit": {
+                  "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                  "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                  }
+                }
+              },
+              "applicableScopes": [
+                "write:pets",
+                "read:pets"
+              ]
+            }
+          },
+          "parameters": {
+            "query": [
+              {
+                "name": "status",
+                "description": "Status values that need to be considered for filter",
+                "required": true,
+                "type": [
+                  "array"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "get",
+          "title": "Finds Pets by tags",
+          "link": "/pet/findByTags/get",
+          "request": {
+            "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing."
+          },
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation",
+              "schema": [
+                {
+                  "name": "",
+                  "type": [
+                    "array"
+                  ],
+                  "required": false,
+                  "properties": [
+                    {
+                      "name": "id",
+                      "type": [
+                        "integer"
+                      ],
+                      "required": false,
+                      "constraints": {
+                        "format": "int64"
+                      }
+                    },
+                    {
+                      "name": "category",
+                      "type": [
+                        "object"
+                      ],
+                      "required": false,
+                      "properties": [
+                        {
+                          "name": "id",
+                          "type": [
+                            "integer"
+                          ],
+                          "required": false,
+                          "constraints": {
+                            "format": "int64"
+                          }
+                        },
+                        {
+                          "name": "name",
+                          "type": [
+                            "string"
+                          ],
+                          "required": false
+                        }
+                      ]
+                    },
+                    {
+                      "name": "name",
+                      "type": [
+                        "string"
+                      ],
+                      "required": true
+                    },
+                    {
+                      "name": "photoUrls",
+                      "type": [
+                        "array"
+                      ],
+                      "required": true,
+                      "subtype": "string"
+                    },
+                    {
+                      "name": "tags",
+                      "type": [
+                        "array"
+                      ],
+                      "required": false,
+                      "properties": [
+                        {
+                          "name": "id",
+                          "type": [
+                            "integer"
+                          ],
+                          "required": false,
+                          "constraints": {
+                            "format": "int64"
+                          }
+                        },
+                        {
+                          "name": "name",
+                          "type": [
+                            "string"
+                          ],
+                          "required": false
+                        }
+                      ]
+                    },
+                    {
+                      "name": "status",
+                      "type": [
+                        "string"
+                      ],
+                      "required": false,
+                      "description": "pet status in the store",
+                      "enum": [
+                        "available",
+                        "pending",
+                        "sold"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "code": "400",
+              "description": "Invalid tag value"
+            }
+          ],
+          "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+          "security": {
+            "petstore_auth": {
+              "name": "petstore_auth",
+              "type": "oauth2",
+              "flows": {
+                "implicit": {
+                  "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                  "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                  }
+                }
+              },
+              "applicableScopes": [
+                "write:pets",
+                "read:pets"
+              ]
+            }
+          },
+          "parameters": {
+            "query": [
+              {
+                "name": "tags",
+                "description": "Tags to filter by",
+                "required": true,
+                "type": [
+                  "array"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "post",
+          "title": "Add a new pet to the store",
+          "link": "/pet/post",
+          "request": {
+            "schema": [
+              {
+                "name": "id",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "constraints": {
+                  "format": "int64"
+                }
+              },
+              {
+                "name": "category",
+                "type": [
+                  "object"
+                ],
+                "required": false,
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": [
+                      "integer"
+                    ],
+                    "required": false,
+                    "constraints": {
+                      "format": "int64"
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  }
+                ]
+              },
+              {
+                "name": "name",
+                "type": [
+                  "string"
+                ],
+                "required": true
+              },
+              {
+                "name": "photoUrls",
+                "type": [
+                  "array"
+                ],
+                "required": true,
+                "subtype": "string"
+              },
+              {
+                "name": "tags",
+                "type": [
+                  "array"
+                ],
+                "required": false,
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": [
+                      "integer"
+                    ],
+                    "required": false,
+                    "constraints": {
+                      "format": "int64"
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  }
+                ]
+              },
+              {
+                "name": "status",
+                "type": [
+                  "string"
+                ],
+                "required": false,
+                "description": "pet status in the store",
+                "enum": [
+                  "available",
+                  "pending",
+                  "sold"
+                ]
+              }
+            ]
+          },
+          "responses": [
+            {
+              "code": "405",
+              "description": "Invalid input"
+            }
+          ],
+          "security": {
+            "petstore_auth": {
+              "name": "petstore_auth",
+              "type": "oauth2",
+              "flows": {
+                "implicit": {
+                  "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                  "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                  }
+                }
+              },
+              "applicableScopes": [
+                "write:pets",
+                "read:pets"
+              ]
+            }
+          },
+          "parameters": {}
+        },
+        {
+          "type": "post",
+          "title": "Updates a pet in the store with form data",
+          "link": "/pet/{petId}/post",
+          "request": {
+            "schema": [
+              {
+                "name": "name",
+                "type": [
+                  "string"
+                ],
+                "required": false,
+                "description": "Updated name of the pet"
+              },
+              {
+                "name": "status",
+                "type": [
+                  "string"
+                ],
+                "required": false,
+                "description": "Updated status of the pet"
+              }
+            ]
+          },
+          "responses": [
+            {
+              "code": "405",
+              "description": "Invalid input"
+            }
+          ],
+          "security": {
+            "petstore_auth": {
+              "name": "petstore_auth",
+              "type": "oauth2",
+              "flows": {
+                "implicit": {
+                  "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                  "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                  }
+                }
+              },
+              "applicableScopes": [
+                "write:pets",
+                "read:pets"
+              ]
+            }
+          },
+          "parameters": {
+            "path": [
+              {
+                "name": "petId",
+                "description": "ID of pet that needs to be updated",
+                "required": true,
+                "type": [
+                  "integer"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "post",
+          "title": "uploads an image",
+          "link": "/pet/{petId}/uploadImage/post",
+          "request": {},
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation",
+              "schema": [
+                {
+                  "name": "code",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int32"
+                  }
+                },
+                {
+                  "name": "type",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false
+                },
+                {
+                  "name": "message",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false
+                }
+              ]
+            }
+          ],
+          "security": {
+            "petstore_auth": {
+              "name": "petstore_auth",
+              "type": "oauth2",
+              "flows": {
+                "implicit": {
+                  "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                  "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                  }
+                }
+              },
+              "applicableScopes": [
+                "write:pets",
+                "read:pets"
+              ]
+            }
+          },
+          "parameters": {
+            "path": [
+              {
+                "name": "petId",
+                "description": "ID of pet to update",
+                "required": true,
+                "type": [
+                  "integer"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "put",
+          "title": "Update an existing pet",
+          "link": "/pet/put",
+          "request": {
+            "schema": [
+              {
+                "name": "id",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "constraints": {
+                  "format": "int64"
+                }
+              },
+              {
+                "name": "category",
+                "type": [
+                  "object"
+                ],
+                "required": false,
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": [
+                      "integer"
+                    ],
+                    "required": false,
+                    "constraints": {
+                      "format": "int64"
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  }
+                ]
+              },
+              {
+                "name": "name",
+                "type": [
+                  "string"
+                ],
+                "required": true
+              },
+              {
+                "name": "photoUrls",
+                "type": [
+                  "array"
+                ],
+                "required": true,
+                "subtype": "string"
+              },
+              {
+                "name": "tags",
+                "type": [
+                  "array"
+                ],
+                "required": false,
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": [
+                      "integer"
+                    ],
+                    "required": false,
+                    "constraints": {
+                      "format": "int64"
+                    }
+                  },
+                  {
+                    "name": "name",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  }
+                ]
+              },
+              {
+                "name": "status",
+                "type": [
+                  "string"
+                ],
+                "required": false,
+                "description": "pet status in the store",
+                "enum": [
+                  "available",
+                  "pending",
+                  "sold"
+                ]
+              }
+            ]
+          },
+          "responses": [
+            {
+              "code": "400",
+              "description": "Invalid ID supplied"
+            },
+            {
+              "code": "404",
+              "description": "Pet not found"
+            },
+            {
+              "code": "405",
+              "description": "Validation exception"
+            }
+          ],
+          "security": {
+            "petstore_auth": {
+              "name": "petstore_auth",
+              "type": "oauth2",
+              "flows": {
+                "implicit": {
+                  "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                  "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                  }
+                }
+              },
+              "applicableScopes": [
+                "write:pets",
+                "read:pets"
+              ]
+            }
+          },
+          "parameters": {}
+        },
+        {
+          "type": "delete",
+          "title": "Deletes a pet",
+          "link": "/pet/{petId}/delete",
+          "request": {},
+          "responses": [
+            {
+              "code": "400",
+              "description": "Invalid ID supplied"
+            },
+            {
+              "code": "404",
+              "description": "Pet not found"
+            }
+          ],
+          "security": {
+            "petstore_auth": {
+              "name": "petstore_auth",
+              "type": "oauth2",
+              "flows": {
+                "implicit": {
+                  "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+                  "scopes": {
+                    "write:pets": "modify pets in your account",
+                    "read:pets": "read your pets"
+                  }
+                }
+              },
+              "applicableScopes": [
+                "write:pets",
+                "read:pets"
+              ]
+            }
+          },
+          "parameters": {
+            "path": [
+              {
+                "name": "petId",
+                "description": "Pet id to delete",
+                "required": true,
+                "type": [
+                  "integer"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "title": "store",
+      "methods": [
+        {
+          "type": "get",
+          "title": "Find purchase order by ID",
+          "link": "/store/order/{orderId}/get",
+          "request": {
+            "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions"
+          },
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation",
+              "schema": [
+                {
+                  "name": "id",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int64"
+                  }
+                },
+                {
+                  "name": "petId",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int64"
+                  }
+                },
+                {
+                  "name": "quantity",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int32"
+                  }
+                },
+                {
+                  "name": "shipDate",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "date-time"
+                  }
+                },
+                {
+                  "name": "status",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false,
+                  "description": "Order Status",
+                  "enum": [
+                    "placed",
+                    "approved",
+                    "delivered"
+                  ]
+                },
+                {
+                  "name": "complete",
+                  "type": [
+                    "boolean"
+                  ],
+                  "required": false
+                }
+              ]
+            },
+            {
+              "code": "400",
+              "description": "Invalid ID supplied"
+            },
+            {
+              "code": "404",
+              "description": "Order not found"
+            }
+          ],
+          "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+          "parameters": {
+            "path": [
+              {
+                "name": "orderId",
+                "description": "ID of pet that needs to be fetched",
+                "required": true,
+                "type": [
+                  "integer"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "get",
+          "title": "Returns pet inventories by status",
+          "link": "/store/inventory/get",
+          "request": {
+            "description": "Returns a map of status codes to quantities"
+          },
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation"
+            }
+          ],
+          "description": "Returns a map of status codes to quantities",
+          "security": {
+            "api_key": {
+              "type": "apiKey",
+              "name": "api_key",
+              "in": "header",
+              "example": "api_key: credentials"
+            }
+          },
+          "parameters": {}
+        },
+        {
+          "type": "post",
+          "title": "Place an order for a pet",
+          "link": "/store/order/post",
+          "request": {
+            "schema": [
+              {
+                "name": "id",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "constraints": {
+                  "format": "int64"
+                }
+              },
+              {
+                "name": "petId",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "constraints": {
+                  "format": "int64"
+                }
+              },
+              {
+                "name": "quantity",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "constraints": {
+                  "format": "int32"
+                }
+              },
+              {
+                "name": "shipDate",
+                "type": [
+                  "string"
+                ],
+                "required": false,
+                "constraints": {
+                  "format": "date-time"
+                }
+              },
+              {
+                "name": "status",
+                "type": [
+                  "string"
+                ],
+                "required": false,
+                "description": "Order Status",
+                "enum": [
+                  "placed",
+                  "approved",
+                  "delivered"
+                ]
+              },
+              {
+                "name": "complete",
+                "type": [
+                  "boolean"
+                ],
+                "required": false
+              }
+            ]
+          },
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation",
+              "schema": [
+                {
+                  "name": "id",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int64"
+                  }
+                },
+                {
+                  "name": "petId",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int64"
+                  }
+                },
+                {
+                  "name": "quantity",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int32"
+                  }
+                },
+                {
+                  "name": "shipDate",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "date-time"
+                  }
+                },
+                {
+                  "name": "status",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false,
+                  "description": "Order Status",
+                  "enum": [
+                    "placed",
+                    "approved",
+                    "delivered"
+                  ]
+                },
+                {
+                  "name": "complete",
+                  "type": [
+                    "boolean"
+                  ],
+                  "required": false
+                }
+              ]
+            },
+            {
+              "code": "400",
+              "description": "Invalid Order"
+            }
+          ],
+          "parameters": {}
+        },
+        {
+          "type": "delete",
+          "title": "Delete purchase order by ID",
+          "link": "/store/order/{orderId}/delete",
+          "request": {
+            "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors"
+          },
+          "responses": [
+            {
+              "code": "400",
+              "description": "Invalid ID supplied"
+            },
+            {
+              "code": "404",
+              "description": "Order not found"
+            }
+          ],
+          "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+          "parameters": {
+            "path": [
+              {
+                "name": "orderId",
+                "description": "ID of the order that needs to be deleted",
+                "required": true,
+                "type": [
+                  "integer"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "title": "user",
+      "methods": [
+        {
+          "type": "get",
+          "title": "Get user by user name",
+          "link": "/user/{username}/get",
+          "request": {},
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation",
+              "schema": [
+                {
+                  "name": "id",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "constraints": {
+                    "format": "int64"
+                  }
+                },
+                {
+                  "name": "username",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false
+                },
+                {
+                  "name": "firstName",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false
+                },
+                {
+                  "name": "lastName",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false
+                },
+                {
+                  "name": "email",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false
+                },
+                {
+                  "name": "password",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false
+                },
+                {
+                  "name": "phone",
+                  "type": [
+                    "string"
+                  ],
+                  "required": false
+                },
+                {
+                  "name": "userStatus",
+                  "type": [
+                    "integer"
+                  ],
+                  "required": false,
+                  "description": "User Status",
+                  "constraints": {
+                    "format": "int32"
+                  }
+                }
+              ]
+            },
+            {
+              "code": "400",
+              "description": "Invalid username supplied"
+            },
+            {
+              "code": "404",
+              "description": "User not found"
+            }
+          ],
+          "parameters": {
+            "path": [
+              {
+                "name": "username",
+                "description": "The name that needs to be fetched. Use user1 for testing. ",
+                "required": true,
+                "type": [
+                  "string"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "get",
+          "title": "Logs out current logged in user session",
+          "link": "/user/logout/get",
+          "request": {},
+          "responses": [
+            {
+              "code": "default",
+              "description": "successful operation"
+            }
+          ],
+          "parameters": {}
+        },
+        {
+          "type": "get",
+          "title": "Logs user into the system",
+          "link": "/user/login/get",
+          "request": {},
+          "responses": [
+            {
+              "code": "200",
+              "description": "successful operation"
+            },
+            {
+              "code": "400",
+              "description": "Invalid username/password supplied"
+            }
+          ],
+          "parameters": {
+            "query": [
+              {
+                "name": "username",
+                "description": "The user name for login",
+                "required": true,
+                "type": [
+                  "string"
+                ]
+              },
+              {
+                "name": "password",
+                "description": "The password for login in clear text",
+                "required": true,
+                "type": [
+                  "string"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "post",
+          "title": "Create user",
+          "link": "/user/post",
+          "request": {
+            "description": "This can only be done by the logged in user.",
+            "schema": [
+              {
+                "name": "id",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "constraints": {
+                  "format": "int64"
+                }
+              },
+              {
+                "name": "username",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "firstName",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "lastName",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "email",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "password",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "phone",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "userStatus",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "description": "User Status",
+                "constraints": {
+                  "format": "int32"
+                }
+              }
+            ]
+          },
+          "responses": [
+            {
+              "code": "default",
+              "description": "successful operation"
+            }
+          ],
+          "description": "This can only be done by the logged in user.",
+          "parameters": {}
+        },
+        {
+          "type": "post",
+          "title": "Creates list of users with given input array",
+          "link": "/user/createWithArray/post",
+          "request": {
+            "schema": [
+              {
+                "name": "",
+                "type": [
+                  "array"
+                ],
+                "required": false,
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": [
+                      "integer"
+                    ],
+                    "required": false,
+                    "constraints": {
+                      "format": "int64"
+                    }
+                  },
+                  {
+                    "name": "username",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "firstName",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "lastName",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "email",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "password",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "phone",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "userStatus",
+                    "type": [
+                      "integer"
+                    ],
+                    "required": false,
+                    "description": "User Status",
+                    "constraints": {
+                      "format": "int32"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "responses": [
+            {
+              "code": "default",
+              "description": "successful operation"
+            }
+          ],
+          "parameters": {}
+        },
+        {
+          "type": "post",
+          "title": "Creates list of users with given input array",
+          "link": "/user/createWithList/post",
+          "request": {
+            "schema": [
+              {
+                "name": "",
+                "type": [
+                  "array"
+                ],
+                "required": false,
+                "properties": [
+                  {
+                    "name": "id",
+                    "type": [
+                      "integer"
+                    ],
+                    "required": false,
+                    "constraints": {
+                      "format": "int64"
+                    }
+                  },
+                  {
+                    "name": "username",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "firstName",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "lastName",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "email",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "password",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "phone",
+                    "type": [
+                      "string"
+                    ],
+                    "required": false
+                  },
+                  {
+                    "name": "userStatus",
+                    "type": [
+                      "integer"
+                    ],
+                    "required": false,
+                    "description": "User Status",
+                    "constraints": {
+                      "format": "int32"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "responses": [
+            {
+              "code": "default",
+              "description": "successful operation"
+            }
+          ],
+          "parameters": {}
+        },
+        {
+          "type": "put",
+          "title": "Updated user",
+          "link": "/user/{username}/put",
+          "request": {
+            "description": "This can only be done by the logged in user.",
+            "schema": [
+              {
+                "name": "id",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "constraints": {
+                  "format": "int64"
+                }
+              },
+              {
+                "name": "username",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "firstName",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "lastName",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "email",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "password",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "phone",
+                "type": [
+                  "string"
+                ],
+                "required": false
+              },
+              {
+                "name": "userStatus",
+                "type": [
+                  "integer"
+                ],
+                "required": false,
+                "description": "User Status",
+                "constraints": {
+                  "format": "int32"
+                }
+              }
+            ]
+          },
+          "responses": [
+            {
+              "code": "400",
+              "description": "Invalid user supplied"
+            },
+            {
+              "code": "404",
+              "description": "User not found"
+            }
+          ],
+          "description": "This can only be done by the logged in user.",
+          "parameters": {
+            "path": [
+              {
+                "name": "username",
+                "description": "name that need to be updated",
+                "required": true,
+                "type": [
+                  "string"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "delete",
+          "title": "Delete user",
+          "link": "/user/{username}/delete",
+          "request": {
+            "description": "This can only be done by the logged in user."
+          },
+          "responses": [
+            {
+              "code": "400",
+              "description": "Invalid username supplied"
+            },
+            {
+              "code": "404",
+              "description": "User not found"
+            }
+          ],
+          "description": "This can only be done by the logged in user.",
+          "parameters": {
+            "path": [
+              {
+                "name": "username",
+                "description": "The name that needs to be deleted",
+                "required": true,
+                "type": [
+                  "string"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "security": {
+    "petstore_auth": {
+      "name": "petstore_auth",
+      "type": "oauth2",
+      "flows": {
+        "implicit": {
+          "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
+          "scopes": {
+            "write:pets": "modify pets in your account",
+            "read:pets": "read your pets"
+          }
+        }
+      }
+    },
+    "api_key": {
+      "type": "apiKey",
+      "name": "api_key",
+      "in": "header",
+      "example": "api_key: credentials"
+    }
+  }
+}

--- a/test/parser/open-api/v3/securityParser.test.js
+++ b/test/parser/open-api/v3/securityParser.test.js
@@ -1,0 +1,161 @@
+import { getSecurity, getUISecurity } from '../../../../src/parser/open-api/v3/securityParser'
+import cloneDeep from 'lodash/cloneDeep'
+
+describe('getSecurity', () => {
+  // Abbreviated Open API definition.
+  const definition = { components: { securitySchemes: {} } }
+
+  test('handles header apiKey type', () => {
+    const def = cloneDeep(definition)
+    def.components.securitySchemes['api_key'] = {
+      type: 'apiKey',
+      name: 'api_key',
+      in: 'header'
+    }
+
+    const security = getSecurity(def)
+    expect(security).toHaveProperty('api_key.type', 'apiKey')
+    expect(security).toHaveProperty('api_key.name', 'api_key')
+    expect(security).toHaveProperty('api_key.example', 'api_key: credentials')
+  })
+
+  test('handles query apiKey type', () => {
+    const def = cloneDeep(definition)
+    def.components.securitySchemes['api_key'] = {
+      type: 'apiKey',
+      name: 'api_key',
+      in: 'query'
+    }
+
+    const security = getSecurity(def)
+    expect(security).toHaveProperty('api_key.type', 'apiKey')
+    expect(security).toHaveProperty('api_key.name', 'api_key')
+    expect(security).toHaveProperty('api_key.example', '?api_key=credentials')
+  })
+
+  test('handles http type', () => {
+    const def = cloneDeep(definition)
+    def.components.securitySchemes['basicAuth'] = {
+      type: 'http',
+      scheme: 'basic'
+    }
+
+    const security = getSecurity(def)
+    expect(security).toHaveProperty('basicAuth.type', 'http')
+    expect(security).toHaveProperty('basicAuth.name', 'basicAuth')
+    expect(security).toHaveProperty('basicAuth.example', 'Authorization: basic credentials')
+  })
+
+  test('handles http type with bearerFormat', () => {
+    const def = cloneDeep(definition)
+    def.components.securitySchemes['JWT'] = {
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT'
+    }
+
+    const security = getSecurity(def)
+    expect(security).toHaveProperty('JWT.type', 'http')
+    expect(security).toHaveProperty('JWT.name', 'JWT')
+    expect(security).toHaveProperty('JWT.example', 'Authorization: bearer credentials')
+    expect(security).toHaveProperty('JWT.bearerFormat', 'JWT')
+  })
+
+  test('handles oauth2 type', () => {
+    const def = cloneDeep(definition)
+    def.components.securitySchemes['oauth2'] = {
+      type: 'oauth2',
+      flows: {
+        implicit: {
+          authorizationUrl: 'https://example.com/api/oauth/dialog',
+          scopes: {
+            'write:pets': 'modify pets in your account',
+            'read:pets': 'read your pets'
+          }
+        },
+        authorizationCode: {
+          authorizationUrl: 'https://example.com/api/oauth/dialog',
+          tokenUrl: 'https://example.com/api/oauth/token',
+          scopes: {
+            'write:pets': 'modify pets in your account',
+            'read:pets': 'read your pets'
+          }
+        }
+      }
+    }
+
+    const security = getSecurity(def)
+    expect(security).toHaveProperty('oauth2.type', 'oauth2')
+    expect(security).toHaveProperty('oauth2.name', 'oauth2')
+  })
+
+  test('handles openIdConnect', () => {
+    const def = cloneDeep(definition)
+    def.components.securitySchemes['openIdConnect'] = {
+      type: 'openIdConnect',
+      openIdConnect: 'https://example.com/openIdConnect'
+    }
+
+    const security = getSecurity(def)
+    expect(security).toHaveProperty('openIdConnect.type', 'openIdConnect')
+    expect(security).toHaveProperty('openIdConnect.name', 'openIdConnect')
+  })
+})
+
+describe('getUISecurity', () => {
+  const securityDefs = {
+    oauth2: {
+      name: 'oauth2',
+      type: 'oauth2',
+      flows: {
+        implicit: {
+          authorizationUrl: 'https://example.com/api/oauth/dialog',
+          scopes: {
+            'write:pets': 'modify pets in your account',
+            'read:pets': 'read your pets'
+          }
+        },
+        authorizationCode: {
+          authorizationUrl: 'https://example.com/api/oauth/dialog',
+          tokenUrl: 'https://example.com/api/oauth/token',
+          scopes: {
+            'write:pets': 'modify pets in your account',
+            'read:pets': 'read your pets'
+          }
+        }
+      }
+    },
+    api_key: {
+      type: 'apiKey',
+      name: 'api_key',
+      in: 'header',
+      example: 'api_key: credentials'
+    }
+  }
+
+  test('can add scopes', () => {
+    const opSecurity = [
+      {
+        oauth2: [ 'write:pets' ]
+      }
+    ]
+
+    expect(getUISecurity(opSecurity, securityDefs)).toHaveProperty('oauth2.applicableScopes', ['write:pets'])
+  })
+
+  test('can add security (no scopes)', () => {
+    const opSecurity = [
+      {
+        'api_key': []
+      }
+    ]
+
+    expect(getUISecurity(opSecurity, securityDefs)).toHaveProperty('api_key.name', 'api_key')
+  })
+
+  test('can remove security', () => {
+    const opSecurity = []
+
+    expect(getUISecurity(opSecurity, securityDefs)).toEqual({})
+  })
+})

--- a/test/parser/open-api/v3/securityParser.test.js
+++ b/test/parser/open-api/v3/securityParser.test.js
@@ -1,7 +1,7 @@
-import { getSecurity, getUISecurity } from '../../../../src/parser/open-api/v3/securityParser'
+import { getSecurityDefinitions, getUISecurity } from '../../../../src/parser/open-api/v3/securityParser'
 import cloneDeep from 'lodash/cloneDeep'
 
-describe('getSecurity', () => {
+describe('#getSecurityDefinitions', () => {
   // Abbreviated Open API definition.
   const definition = { components: { securitySchemes: {} } }
 
@@ -13,7 +13,7 @@ describe('getSecurity', () => {
       in: 'header'
     }
 
-    const security = getSecurity(def)
+    const security = getSecurityDefinitions(def)
     expect(security).toHaveProperty('api_key.type', 'apiKey')
     expect(security).toHaveProperty('api_key.name', 'api_key')
     expect(security).toHaveProperty('api_key.example', 'api_key: credentials')
@@ -27,7 +27,7 @@ describe('getSecurity', () => {
       in: 'query'
     }
 
-    const security = getSecurity(def)
+    const security = getSecurityDefinitions(def)
     expect(security).toHaveProperty('api_key.type', 'apiKey')
     expect(security).toHaveProperty('api_key.name', 'api_key')
     expect(security).toHaveProperty('api_key.example', '?api_key=credentials')
@@ -40,7 +40,7 @@ describe('getSecurity', () => {
       scheme: 'basic'
     }
 
-    const security = getSecurity(def)
+    const security = getSecurityDefinitions(def)
     expect(security).toHaveProperty('basicAuth.type', 'http')
     expect(security).toHaveProperty('basicAuth.name', 'basicAuth')
     expect(security).toHaveProperty('basicAuth.example', 'Authorization: basic credentials')
@@ -54,7 +54,7 @@ describe('getSecurity', () => {
       bearerFormat: 'JWT'
     }
 
-    const security = getSecurity(def)
+    const security = getSecurityDefinitions(def)
     expect(security).toHaveProperty('JWT.type', 'http')
     expect(security).toHaveProperty('JWT.name', 'JWT')
     expect(security).toHaveProperty('JWT.example', 'Authorization: bearer credentials')
@@ -84,7 +84,7 @@ describe('getSecurity', () => {
       }
     }
 
-    const security = getSecurity(def)
+    const security = getSecurityDefinitions(def)
     expect(security).toHaveProperty('oauth2.type', 'oauth2')
     expect(security).toHaveProperty('oauth2.name', 'oauth2')
   })
@@ -96,13 +96,13 @@ describe('getSecurity', () => {
       openIdConnect: 'https://example.com/openIdConnect'
     }
 
-    const security = getSecurity(def)
+    const security = getSecurityDefinitions(def)
     expect(security).toHaveProperty('openIdConnect.type', 'openIdConnect')
     expect(security).toHaveProperty('openIdConnect.name', 'openIdConnect')
   })
 })
 
-describe('getUISecurity', () => {
+describe('#getUISecurity', () => {
   const securityDefs = {
     oauth2: {
       name: 'oauth2',

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,10 @@ ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
+
 ansi-html@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
@@ -117,8 +121,8 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
 ansi-styles@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.0.0.tgz#5404e93a544c4fec7f048262977bebfe3155e0c1"
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
   dependencies:
     color-convert "^1.0.0"
 
@@ -136,8 +140,8 @@ append-transform@^0.4.0:
     default-require-extensions "^1.0.0"
 
 aproba@^1.0.3:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.1.tgz#95d3600f07710aa0e9298c726ad5ecf2eacbabab"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
 
 are-we-there-yet@~1.1.2:
   version "1.1.4"
@@ -788,8 +792,8 @@ babel-plugin-transform-object-rest-spread@^6.22.0:
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz#4398910c358441dc4cef18787264d0412ed36b37"
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz#67e2bf1f1e9c93ab08db96792e05392bf2cc28d1"
   dependencies:
     babel-runtime "^6.22.0"
 
@@ -968,16 +972,20 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     to-fast-properties "^1.0.1"
 
 babylon@^6.13.0, babylon@^6.17.0, babylon@^6.17.2:
-  version "6.17.2"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.2.tgz#201d25ef5f892c41bae49488b08db0dd476e9f5c"
+  version "6.17.3"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.3.tgz#1327d709950b558f204e5352587fd0290f8d8e48"
 
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
 
-balanced-match@^0.4.1, balanced-match@^0.4.2:
+balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
+
+balanced-match@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
 balloon-css@^0.4.0:
   version "0.4.0"
@@ -1052,10 +1060,10 @@ boom@2.x.x:
     hoek "2.x.x"
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
   dependencies:
-    balanced-match "^0.4.1"
+    balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 braces@^1.8.2:
@@ -1146,10 +1154,6 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-shims@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
-
 buffer-xor@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -1232,8 +1236,8 @@ caniuse-api@^1.5.2:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000676"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000676.tgz#82ea578237637c8ff34a28acaade373b624c4ea8"
+  version "1.0.30000686"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000686.tgz#d55b479ed6e6402c1fd3f1fd8f46e694d86ea464"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1286,8 +1290,8 @@ circular-json@^0.3.1:
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
 clap@^1.0.9:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/clap/-/clap-1.1.3.tgz#b3bd36e93dd4cbfb395a3c26896352445265c05b"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.0.tgz#59c90fe3e137104746ff19469a27a634ff68c857"
   dependencies:
     chalk "^1.1.3"
 
@@ -1296,8 +1300,8 @@ classnames@^2.2.5:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
 clean-css@4.1.x:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.3.tgz#07cfe8980edb20d455ddc23aadcf1e04c6e509ce"
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.4.tgz#eec8811db27457e0078d8ca921fa81b72fa82bf4"
   dependencies:
     source-map "0.5.x"
 
@@ -1327,14 +1331,13 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-clone-deep@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.2.4.tgz#4e73dd09e9fb971cc38670c5dced9c1896481cc6"
+clone-deep@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-0.3.0.tgz#348c61ae9cdbe0edfe053d91ff4cc521d790ede8"
   dependencies:
-    for-own "^0.1.3"
+    for-own "^1.0.0"
     is-plain-object "^2.0.1"
-    kind-of "^3.0.2"
-    lazy-cache "^1.0.3"
+    kind-of "^3.2.2"
     shallow-clone "^0.1.2"
 
 clone@^1.0.2:
@@ -1346,8 +1349,8 @@ co@^4.6.0:
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 coa@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.2.tgz#2ba9fec3b4aa43d7a49d7e6c3561e92061b6bcec"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/coa/-/coa-1.0.3.tgz#1b54a5e1dcf77c990455d4deea98c564416dc893"
   dependencies:
     q "^1.1.2"
 
@@ -1546,6 +1549,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-class@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 cross-spawn@4.0.2, cross-spawn@^4.0.0:
   version "4.0.2"
@@ -1876,8 +1887,8 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 electron-to-chromium@^1.2.7:
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz#1b3a5eace6e087bb5e257a100b0cbfe81b2891fc"
+  version "1.3.14"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz#64af0f9efd3c3c6acd57d71f83b49ca7ee9c4b43"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2050,12 +2061,12 @@ eslint-plugin-promise@^3.5.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
 
 eslint-plugin-react@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.0.1.tgz#e78107e1e559c6e2b17786bb67c2e2a010ad0d2f"
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz#27770acf39f5fd49cd0af4083ce58104eb390d4c"
   dependencies:
     doctrine "^2.0.0"
     has "^1.0.1"
-    jsx-ast-utils "^1.3.4"
+    jsx-ast-utils "^1.4.1"
 
 eslint-plugin-standard@^3.0.1:
   version "3.0.1"
@@ -2232,7 +2243,7 @@ extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
-external-editor@^2.0.1:
+external-editor@^2.0.1, external-editor@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
   dependencies:
@@ -2401,9 +2412,15 @@ for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
-for-own@^0.1.3, for-own@^0.1.4:
+for-own@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
+  dependencies:
+    for-in "^1.0.1"
+
+for-own@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
   dependencies:
     for-in "^1.0.1"
 
@@ -2411,7 +2428,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@^2.1.1, form-data@~2.1.1:
+form-data@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.2.0.tgz#9a5e3b9295f980b2623cf64fa238b14cebca707b"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
+
+form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
   dependencies:
@@ -2444,11 +2469,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
 fsevents@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.1.tgz#f19fd28f43eeaf761680e519a203c4d0b3d31aff"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
   dependencies:
     nan "^2.3.0"
-    node-pre-gyp "^0.6.29"
+    node-pre-gyp "^0.6.36"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -2539,8 +2564,8 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@~7.1.1:
     path-is-absolute "^1.0.0"
 
 globals@^9.0.0, globals@^9.17.0:
-  version "9.17.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.17.0.tgz#0c0ca696d9b9bb694d2e5470bd37777caad50286"
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -2554,11 +2579,11 @@ globby@^5.0.0:
     pinkie-promise "^2.0.0"
 
 globule@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/globule/-/globule-1.1.0.tgz#c49352e4dc183d85893ee825385eb994bb6df45f"
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.0.tgz#1dc49c6822dd9e8a2fa00ba2a295006e8664bd09"
   dependencies:
     glob "~7.1.1"
-    lodash "~4.16.4"
+    lodash "~4.17.4"
     minimatch "~3.0.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
@@ -2660,8 +2685,8 @@ he@1.1.x:
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 history@^4.5.1, history@^4.6.0, history@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/history/-/history-4.6.1.tgz#911cf8eb65728555a94f2b12780a0c531a14d2fd"
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.6.2.tgz#716e863e1da0e97a028eed6da644061dd1e1ed1d"
   dependencies:
     invariant "^2.2.1"
     loose-envify "^1.2.0"
@@ -2798,8 +2823,8 @@ iconv-lite@0.4.13:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
 iconv-lite@^0.4.17, iconv-lite@~0.4.13:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.17.tgz#4fdaa3b38acbc2c031b045d0edcdfe1ecab18c8d"
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -2860,7 +2885,7 @@ ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-inquirer@3.0.6, inquirer@^3.0.6:
+inquirer@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.0.6.tgz#e04aaa9d05b7a3cb9b0f407d04375f0447190347"
   dependencies:
@@ -2874,6 +2899,25 @@ inquirer@3.0.6, inquirer@^3.0.6:
     mute-stream "0.0.7"
     run-async "^2.2.0"
     rx "^4.1.0"
+    string-width "^2.0.0"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
+
+inquirer@^3.0.6:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.1.0.tgz#e05400d48b94937c2d3caa7038663ba9189aab01"
+  dependencies:
+    ansi-escapes "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
     string-width "^2.0.0"
     strip-ansi "^3.0.0"
     through "^2.3.6"
@@ -2985,9 +3029,15 @@ is-my-json-valid@^2.16.0:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
-is-number@^2.0.2, is-number@^2.1.0:
+is-number@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-number@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
 
@@ -3368,12 +3418,6 @@ jest@^20.0.4:
   dependencies:
     jest-cli "^20.0.4"
 
-jodid25519@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/jodid25519/-/jodid25519-1.0.2.tgz#06d4912255093419477d425633606e0e90782967"
-  dependencies:
-    jsbn "~0.1.0"
-
 js-base64@^2.1.8, js-base64@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
@@ -3496,7 +3540,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jsx-ast-utils@^1.3.4:
+jsx-ast-utils@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
@@ -3510,9 +3554,15 @@ kind-of@^2.0.1:
   dependencies:
     is-buffer "^1.0.2"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
+  dependencies:
+    is-buffer "^1.1.5"
+
+kind-of@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
 
@@ -3634,13 +3684,9 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-lodash@~4.16.4:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3664,11 +3710,11 @@ lower-case@^1.1.1:
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
 
 lru-cache@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
-    pseudomap "^1.0.1"
-    yallist "^2.0.0"
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
 
 macaddress@^0.2.8:
   version "0.2.8"
@@ -3869,15 +3915,15 @@ no-case@^2.2.0:
     lower-case "^1.1.1"
 
 node-fetch@^1.0.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.0.tgz#3ff6c56544f9b7fb00682338bb55ee6f54a8a0ef"
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
 node-gyp@^3.3.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.1.tgz#19561067ff185464aded478212681f47fd578cbc"
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
   dependencies:
     fstream "^1.0.0"
     glob "^7.0.3"
@@ -3934,7 +3980,7 @@ node-notifier@^5.0.2:
     shellwords "^0.1.0"
     which "^1.2.12"
 
-node-pre-gyp@^0.6.29:
+node-pre-gyp@^0.6.36:
   version "0.6.36"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
   dependencies:
@@ -4047,7 +4093,7 @@ object-assign@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -4300,6 +4346,10 @@ performance-now@^0.2.0:
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -4568,8 +4618,8 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     supports-color "^3.2.3"
 
 postcss@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.1.tgz#000dbd1f8eef217aa368b9a212c5fc40b2a8f3f2"
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.2.tgz#5c4fea589f0ac3b00caa75b1cbc3a284195b7e5d"
   dependencies:
     chalk "^1.1.3"
     source-map "^0.5.6"
@@ -4623,7 +4673,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
@@ -4641,7 +4691,7 @@ prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
-pseudomap@^1.0.1:
+pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
@@ -4695,15 +4745,17 @@ querystringify@~1.0.0:
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
 randomatic@^1.1.3:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.6.tgz#110dcabff397e9dcff7c0789ccc0a49adf1ec5bb"
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
   dependencies:
-    is-number "^2.0.2"
-    kind-of "^3.0.2"
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 randombytes@^2.0.0, randombytes@^2.0.1:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.3.tgz#674c99760901c3c4112771a31e521dc349cc09ec"
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.0.5.tgz#dc009a246b8d09a177b4b7a0ae77bc570f4b1b79"
+  dependencies:
+    safe-buffer "^5.1.0"
 
 range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
@@ -4719,8 +4771,8 @@ rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-addons-create-fragment@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.5.4.tgz#048acb2f332a3f450beae0be66824ed91e66e122"
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/react-addons-create-fragment/-/react-addons-create-fragment-15.6.0.tgz#af91a22b1fb095dd01f1afba43bfd0ef589d8b20"
   dependencies:
     fbjs "^0.8.4"
     loose-envify "^1.3.1"
@@ -4763,13 +4815,13 @@ react-document-title@^2.0.2:
     react-side-effect "^1.0.2"
 
 react-dom@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "~15.5.7"
+    prop-types "^15.5.10"
 
 react-json-view@^1.8.4:
   version "1.8.4"
@@ -4810,20 +4862,21 @@ react-side-effect@^1.0.2:
     shallowequal "^1.0.1"
 
 react-test-renderer@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
   dependencies:
     fbjs "^0.8.9"
     object-assign "^4.1.0"
 
 react@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
   dependencies:
+    create-react-class "^15.6.0"
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "^15.5.7"
+    prop-types "^15.5.10"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -4865,14 +4918,14 @@ readable-stream@1.0:
     string_decoder "~0.10.x"
 
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
+  version "2.2.11"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.11.tgz#0796b31f8d7688007ff0b93a8088d34aa17c0f72"
   dependencies:
-    buffer-shims "~1.0.0"
     core-util-is "~1.0.0"
     inherits "~2.0.1"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
+    safe-buffer "~5.0.1"
     string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
@@ -4966,8 +5019,8 @@ relateurl@0.2.x:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
 remove-trailing-separator@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz#615ebb96af559552d4bf4057c8436d486ab63cc4"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz#69b062d978727ad14dc6b56ba4ab772fd8d70511"
 
 renderkid@^2.0.1:
   version "2.0.1"
@@ -5089,13 +5142,27 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
+
 rx@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/rx/-/rx-4.1.0.tgz#a5f13ff79ef3b740fe30aa803fb09f98805d4782"
 
-safe-buffer@^5.0.1:
+safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+safe-buffer@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
 
 sane@~1.6.0:
   version "1.6.0"
@@ -5119,14 +5186,14 @@ sass-graph@^2.1.1:
     yargs "^7.0.0"
 
 sass-loader@^6.0.3:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.5.tgz#a847910f36442aa56c5985879d54eb519e24a328"
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.6.tgz#e9d5e6c1f155faa32a4b26d7a9b7107c225e40f9"
   dependencies:
     async "^2.1.5"
-    clone-deep "^0.2.4"
+    clone-deep "^0.3.0"
     loader-utils "^1.0.1"
     lodash.tail "^4.1.1"
-    pify "^2.3.0"
+    pify "^3.0.0"
 
 sax@^1.2.1, sax@~1.2.1:
   version "1.2.2"
@@ -5413,8 +5480,8 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.0.tgz#ff2a3e4fd04497555fed97b39a0fd82fafb3a33c"
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.13.1.tgz#512df6da6287144316dc4c18fe1cf1d940739be3"
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -5423,7 +5490,6 @@ sshpk@^1.7.0:
   optionalDependencies:
     bcrypt-pbkdf "^1.0.0"
     ecc-jsbn "~0.1.1"
-    jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
@@ -5445,8 +5511,8 @@ stream-browserify@^2.0.1:
     readable-stream "^2.0.2"
 
 stream-http@^2.3.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.1.tgz#546a51741ad5a6b07e9e31b0b10441a917df528a"
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/stream-http/-/stream-http-2.7.2.tgz#40a050ec8dc3b53b33d9909415c02c0bf1abfbad"
   dependencies:
     builtin-status-codes "^3.0.0"
     inherits "^2.0.1"
@@ -5484,10 +5550,10 @@ string_decoder@^0.10.25, string_decoder@~0.10.x:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
 string_decoder@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.1.tgz#62e200f039955a6810d8df0a33ffc0f013662d98"
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.0.2.tgz#b29e1f4e1125fa97a10382b8a533737b7491e179"
   dependencies:
-    safe-buffer "^5.0.1"
+    safe-buffer "~5.0.1"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -5618,8 +5684,8 @@ text-table@0.2.0, text-table@~0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
 throat@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/throat/-/throat-3.0.0.tgz#e7c64c867cbb3845f10877642f7b60055b8ec0d6"
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
 through@^2.3.6:
   version "2.3.8"
@@ -5723,15 +5789,15 @@ uc.micro@^1.0.1, uc.micro@^1.0.3:
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 
 uglify-js@3.0.x:
-  version "3.0.14"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.14.tgz#2697af126fd215aac556facb1edfb17875204760"
+  version "3.0.16"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.0.16.tgz#fe394c6708a79ffbf21ca15d6591b16334501aec"
   dependencies:
     commander "~2.9.0"
     source-map "~0.5.1"
 
 uglify-js@^2.6, uglify-js@^2.8.27:
-  version "2.8.27"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.27.tgz#47787f912b0f242e5b984343be8e35e95f694c9c"
+  version "2.8.29"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
     source-map "~0.5.1"
     yargs "~3.10.0"
@@ -6109,7 +6175,7 @@ y18n@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-3.2.1.tgz#6d15fba884c08679c0d77e88e7759e811e07fa41"
 
-yallist@^2.0.0:
+yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 


### PR DESCRIPTION
- parser can now handle `components.securitySchemes`, which will add `security` definitions to the parsed definition
- `SecurityContainer` component added to visualise security schemes at an API level (not per method!)
- minor CSS tweaks (I tried to restrain!) such as abstracting `.inline-pairs` so the CSS can be reused for other components. (I didn't want to create a `<dl>` component, it just felt like overkill.)

#115 has been raised for visualising the security scheme per method.