### PR TITLE
Add support for top level Tags. Closes #111

### DIFF
--- a/docs/open-api-v3-support.md
+++ b/docs/open-api-v3-support.md
@@ -30,7 +30,7 @@ This document outlines this project's support for visualising the [Open API V3][
 - [x] [paths](#paths-object)
 - [ ] [components](#components-object)
 - [x] [security](#security-requirement-object)
-- [ ] [tags](#tag-object)
+- [x] [tags](#tag-object)
 - [ ] [externalDocs](#external-documentation-object)
 
 ### [Info](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#info-object) object
@@ -207,8 +207,8 @@ See [parameter](#parameter-object) object.
 
 ### [Tag](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#tag-object) object
 
-- [ ] name
-- [ ] description
+- [x] name
+- [x] description
 - [ ] [externalDocs](#external-documentation-object)
 
 ### [Reference](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#reference-object) object

--- a/src/components/Description/Description.scss
+++ b/src/components/Description/Description.scss
@@ -2,3 +2,7 @@
 .description-inline p {
   display: inline;
 }
+
+.description p {
+  margin: .5rem 0;
+}

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -40,6 +40,8 @@ export default class Navigation extends Component {
             <NavigationTag
               key={tag.title}
               title={tag.title}
+              handle={tag.handle}
+              description={tag.description}
               methods={tag.methods}
               shouldBeExpanded={shouldBeExpanded}
               onClick={this.onClick}

--- a/src/components/Navigation/Navigation.js
+++ b/src/components/Navigation/Navigation.js
@@ -40,7 +40,6 @@ export default class Navigation extends Component {
             <NavigationTag
               key={tag.title}
               title={tag.title}
-              handle={tag.handle}
               description={tag.description}
               methods={tag.methods}
               shouldBeExpanded={shouldBeExpanded}

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -9,14 +9,23 @@
   top: 0;
   box-sizing: border-box;
   overflow-y: auto;
+
   a {
     text-decoration: none;
   }
+
   .indicator {
     float: right;
+    display: block;
+    margin-top: 5px;
   }
 
   > div {
-    margin: 25px 20px;
+    margin: .5rem 0;
+    padding: 1rem;
+
+    & + div {
+      border-top: 1px solid darken(#FFF, 80%);
+    }
   }
 }

--- a/src/components/Navigation/Navigation.scss
+++ b/src/components/Navigation/Navigation.scss
@@ -10,22 +10,13 @@
   box-sizing: border-box;
   overflow-y: auto;
 
-  a {
-    text-decoration: none;
-  }
-
   .indicator {
     float: right;
     display: block;
     margin-top: 5px;
   }
 
-  > div {
-    margin: .5rem 0;
-    padding: 1rem;
-
-    & + div {
-      border-top: 1px solid darken(#FFF, 80%);
-    }
+  > div + div {
+    border-top: 1px solid darken(#FFF, 80%);
   }
 }

--- a/src/components/NavigationMethod/NavigationMethod.scss
+++ b/src/components/NavigationMethod/NavigationMethod.scss
@@ -2,10 +2,10 @@
 
 .nav-method {
   display: flex;
-  margin: 10px 5px;
-  padding: 10px;
+  padding: .5rem;
+  margin-left: -.5rem;
   font-size: smaller;
-  color: white;
+  color: #FFF;
 
   &.active {
     background-color: $content-background;
@@ -19,18 +19,12 @@
     display: none;
   }
 
-  &:first-child {
-    margin-top: 20px;
-  }
-
   .method-type {
     width: 55px;
   }
 
   .method-title {
-    padding-left: 5px;
     width: calc(100% - 55px);
-    text-indent: 0;
   }
 }
 

--- a/src/components/NavigationMethod/NavigationMethod.scss
+++ b/src/components/NavigationMethod/NavigationMethod.scss
@@ -1,9 +1,12 @@
 @import '../../base.scss';
 
+.nav-tag-methods {
+  margin-bottom: .5gqgrem
+}
+
 .nav-method {
   display: flex;
-  padding: .5rem;
-  margin-left: -.5rem;
+  padding: .7rem 1.5rem;
   font-size: smaller;
   color: #FFF;
 

--- a/src/components/NavigationTag/NavigationTag.js
+++ b/src/components/NavigationTag/NavigationTag.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+
 import Indicator from '../Indicator/Indicator'
 import NavigationMethod from '../NavigationMethod/NavigationMethod'
+import Description from '../Description/Description'
 
 import './NavigationTag.scss'
 
@@ -22,6 +24,10 @@ export default class NavigationTag extends Component {
   componentWillMount () {
     const { title, methods, location, onClick } = this.props
 
+    if (!methods) {
+      return null
+    }
+
     const method = methods.find(
       (method) => (`#${method.link}` === location.hash)
     )
@@ -36,7 +42,7 @@ export default class NavigationTag extends Component {
   }
 
   render () {
-    const { title, shouldBeExpanded, methods, location } = this.props
+    const { title, handle, description, shouldBeExpanded, methods, location } = this.props
 
     // If tag has any method that matches location hash, then it is considered active
     let isActiveTag = false
@@ -64,7 +70,9 @@ export default class NavigationTag extends Component {
           onClick={this.handleClick}
         >
           {title}
+          {handle && <code className='nav-tagHandle'>{handle}</code>}
           <Indicator direction={indicatorDirection} />
+          {description && <Description description={description} />}
         </a>
         <div className='nav-tag-methods'>
           {methods && methods.map((method) => {
@@ -80,8 +88,10 @@ export default class NavigationTag extends Component {
 
 NavigationTag.propTypes = {
   title: PropTypes.string.isRequired,
+  handle: PropTypes.string,
+  description: PropTypes.string,
   methods: PropTypes.array,
   shouldBeExpanded: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
-  location: PropTypes.object
+  location: PropTypes.object.isRequired
 }

--- a/src/components/NavigationTag/NavigationTag.js
+++ b/src/components/NavigationTag/NavigationTag.js
@@ -42,7 +42,7 @@ export default class NavigationTag extends Component {
   }
 
   render () {
-    const { title, handle, description, shouldBeExpanded, methods, location } = this.props
+    const { title, description, shouldBeExpanded, methods, location } = this.props
 
     // If tag has any method that matches location hash, then it is considered active
     let isActiveTag = false
@@ -69,8 +69,7 @@ export default class NavigationTag extends Component {
           href={`#${title}`}
           onClick={this.handleClick}
         >
-          {title}
-          {handle && <code className='nav-tagHandle'>{handle}</code>}
+          <span>{title}</span>
           <Indicator direction={indicatorDirection} />
           {description && <Description description={description} />}
         </a>
@@ -88,7 +87,6 @@ export default class NavigationTag extends Component {
 
 NavigationTag.propTypes = {
   title: PropTypes.string.isRequired,
-  handle: PropTypes.string,
   description: PropTypes.string,
   methods: PropTypes.array,
   shouldBeExpanded: PropTypes.bool,

--- a/src/components/NavigationTag/NavigationTag.scss
+++ b/src/components/NavigationTag/NavigationTag.scss
@@ -2,8 +2,7 @@
 
 .nav-tag {
   display: block;
-  color: white;
-  margin-top: 15px;
+  color: #FFF;
 
   &.active {
     background-color: rgb(12, 18, 29);
@@ -16,4 +15,11 @@
   &.is-closed {
     display: none;
   }
+}
+
+.nav-tagHandle {
+  display: inline-block;
+  padding: .4rem;
+  margin-left: .5rem;
+  background-color: $content-background;
 }

--- a/src/components/NavigationTag/NavigationTag.scss
+++ b/src/components/NavigationTag/NavigationTag.scss
@@ -1,8 +1,15 @@
-@import '../../base.scss';
-
 .nav-tag {
   display: block;
+  padding: 1rem 1rem .5rem;
   color: #FFF;
+
+  &:hover {
+    text-decoration: none;
+
+    span {
+      text-decoration: underline;
+    }
+  }
 
   &.active {
     background-color: rgb(12, 18, 29);
@@ -15,11 +22,4 @@
   &.is-closed {
     display: none;
   }
-}
-
-.nav-tagHandle {
-  display: inline-block;
-  padding: .4rem;
-  margin-left: .5rem;
-  background-color: $content-background;
 }

--- a/test/components/NavigationTag.test.js
+++ b/test/components/NavigationTag.test.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import NavigationTag from './../../src/components/NavigationTag/NavigationTag'
+import renderer from 'react-test-renderer'
+
+describe('<NavigationTag />', () => {
+  const location = {
+    hash: '#pets'
+  }
+
+  it('renders with minimum props', () => {
+    const tree = renderer.create(
+      <NavigationTag title='pets' onClick={jest.fn()} location={location} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders with methods', () => {
+    const methods = [{
+      type: 'get',
+      title: 'Get pets',
+      link: 'pets'
+    },
+    {
+      type: 'get',
+      title: 'Get pets',
+      link: 'pets/:id'
+    }]
+
+    const tree = renderer.create(
+      <NavigationTag title='pets' onClick={jest.fn()} location={location} methods={methods} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders with description', () => {
+    const tree = renderer.create(
+      <NavigationTag title='Pets' handle='pets' description='Access to Pets' onClick={jest.fn()} location={location} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/test/components/__snapshots__/NavigationTag.test.js.snap
+++ b/test/components/__snapshots__/NavigationTag.test.js.snap
@@ -7,12 +7,9 @@ exports[`<NavigationTag /> renders with description 1`] = `
     href="#Pets"
     onClick={[Function]}
   >
-    Pets
-    <code
-      className="nav-tagHandle"
-    >
-      pets
-    </code>
+    <span>
+      Pets
+    </span>
     <div
       className="indicator indicator--right"
     >
@@ -45,7 +42,9 @@ exports[`<NavigationTag /> renders with methods 1`] = `
     href="#pets"
     onClick={[Function]}
   >
-    pets
+    <span>
+      pets
+    </span>
     <div
       className="indicator indicator--bottom"
     >
@@ -100,7 +99,9 @@ exports[`<NavigationTag /> renders with minimum props 1`] = `
     href="#pets"
     onClick={[Function]}
   >
-    pets
+    <span>
+      pets
+    </span>
     <div
       className="indicator indicator--right"
     >

--- a/test/components/__snapshots__/NavigationTag.test.js.snap
+++ b/test/components/__snapshots__/NavigationTag.test.js.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<NavigationTag /> renders with description 1`] = `
+<div>
+  <a
+    className="nav-tag"
+    href="#Pets"
+    onClick={[Function]}
+  >
+    Pets
+    <code
+      className="nav-tagHandle"
+    >
+      pets
+    </code>
+    <div
+      className="indicator indicator--right"
+    >
+      <img
+        alt=""
+        src="test-file-stub"
+        title="arrow"
+      />
+    </div>
+    <div
+      className="description"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<p>Access to Pets</p>
+        ",
+        }
+      }
+    />
+  </a>
+  <div
+    className="nav-tag-methods"
+  />
+</div>
+`;
+
+exports[`<NavigationTag /> renders with methods 1`] = `
+<div>
+  <a
+    className="nav-tag"
+    href="#pets"
+    onClick={[Function]}
+  >
+    pets
+    <div
+      className="indicator indicator--bottom"
+    >
+      <img
+        alt=""
+        src="test-file-stub"
+        title="arrow"
+      />
+    </div>
+  </a>
+  <div
+    className="nav-tag-methods"
+  >
+    <a
+      className="nav-method active open"
+      href="#pets"
+    >
+      <span
+        className="method-type"
+      >
+        GET
+      </span>
+      <span
+        className="method-title"
+      >
+        Get pets
+      </span>
+    </a>
+    <a
+      className="nav-method open"
+      href="#pets/:id"
+    >
+      <span
+        className="method-type"
+      >
+        GET
+      </span>
+      <span
+        className="method-title"
+      >
+        Get pets
+      </span>
+    </a>
+  </div>
+</div>
+`;
+
+exports[`<NavigationTag /> renders with minimum props 1`] = `
+<div>
+  <a
+    className="nav-tag"
+    href="#pets"
+    onClick={[Function]}
+  >
+    pets
+    <div
+      className="indicator indicator--right"
+    >
+      <img
+        alt=""
+        src="test-file-stub"
+        title="arrow"
+      />
+    </div>
+  </a>
+  <div
+    className="nav-tag-methods"
+  />
+</div>
+`;

--- a/test/parser/open-api/v3/data/inputs/carrier.json
+++ b/test/parser/open-api/v3/data/inputs/carrier.json
@@ -10,6 +10,12 @@
     "description": "Manipulate Carriers and the Merchants' connections to them.",
     "version": "0.0.1"
   },
+  "tags": [
+    {
+      "name": "Carriers",
+      "description": "Access to Carriers"
+    }
+  ],
   "paths": {
     "/carriers": {
       "get": {

--- a/test/parser/open-api/v3/data/outputs/carrier.json
+++ b/test/parser/open-api/v3/data/outputs/carrier.json
@@ -5,6 +5,8 @@
   "navigation": [
     {
       "title": "Carriers",
+      "handle": "Carriers",
+      "description": "Access to Carriers",
       "methods": [
         {
           "type": "get",

--- a/test/parser/open-api/v3/data/outputs/petstore.json
+++ b/test/parser/open-api/v3/data/outputs/petstore.json
@@ -5,6 +5,12 @@
   "navigation": [
     {
       "title": "pet",
+      "handle": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      },
       "methods": [
         {
           "type": "get",
@@ -50,6 +56,8 @@
     },
     {
       "title": "store",
+      "handle": "store",
+      "description": "Access to Petstore orders",
       "methods": [
         {
           "type": "get",
@@ -75,6 +83,12 @@
     },
     {
       "title": "user",
+      "handle": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      },
       "methods": [
         {
           "type": "get",


### PR DESCRIPTION
The parser supports `externalDocs`, but this is not handled by the components yet (see #112)