### PR TITLE
Add deployment via Travis to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ deploy:
   provider: script
   skip_cleanup: true
   script:
-    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+    - npm set //registry.npmjs.org/:_authToken ${NPM_TOKEN}
     - npm run release
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,12 @@ script:
   - yarn build
   - yarn test
   - yarn test:bench
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+    - npm run release
+  on:
+    tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+- Initial release of Lincoln 🎩

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "react-lincoln",
+  "version": "0.0.1",
   "description": "Meet Lincoln, a React component for rendering OpenAPI v3 definitions.",
   "license": "MIT",
   "repository": {
@@ -42,6 +43,8 @@
     "build:library": "./scripts/build.bash",
     "dash": "webpack-dashboard -- yarn start",
     "lint": "eslint src test",
+    "preversion": "npm run lint && npm run build && npm run test",
+    "release": "cd dist/library && npm publish",
     "start": "webpack-dev-server --config ./webpack.config.dev.js",
     "test": "jest",
     "test:bench": "node -r babel-register test/benchmark/parser.js",


### PR DESCRIPTION
Largely based off the release method in https://github.com/temando/serverless-openapi-documentation

Will potentially do a few more doc updates to README once this/or #163 are in.