### PR TITLE
Track the official v3 specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![MIT License](https://img.shields.io/github/license/temando/open-api-renderer.svg)](https://en.wikipedia.org/wiki/MIT_License)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
-Meet Lincoln, a [React](https://facebook.github.io/react/) component for rendering [OpenAPI](https://www.openapis.org) definitions. The project is tracking against [v3.0.0-rc2](docs/open-api-v3-support.md) of the OpenAPI specification.
+Meet Lincoln, a [React](https://facebook.github.io/react/) component for rendering [OpenAPI](https://www.openapis.org) definitions. The project is tracking against [v3.0.0](docs/open-api-v3-support.md) of the OpenAPI specification.
 
 Lincoln aims to support evergreen browsers, such as Chrome, Firefox, Safari and IE11+. It is responsive and should be usable on most modern devices.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![MIT License](https://img.shields.io/github/license/temando/open-api-renderer.svg)](https://en.wikipedia.org/wiki/MIT_License)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
-Meet Lincoln, a [React](https://facebook.github.io/react/) component for rendering [OpenAPI](https://www.openapis.org) definitions. The project is tracking against [v3.0.0](docs/open-api-v3-support.md) of the OpenAPI specification.
+Meet Lincoln, a [React](https://facebook.github.io/react/) component for rendering [OpenAPI](https://www.openapis.org) documents. The project is tracking against [v3.0.0](docs/open-api-v3-support.md) of the OpenAPI specification.
 
 Lincoln aims to support evergreen browsers, such as Chrome, Firefox, Safari and IE11+. It is responsive and should be usable on most modern devices.
 
@@ -51,14 +51,14 @@ The following configuration options are available:
 
 | property                        | required | type    | description                                                                                                                                                                                                                         |
 | ------------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `definitionUrl` or `definition` | ✔        | string  | CORS-enabled URL to, or contents of, Open API v3 definition to render. Supports JSON or YAML.                                                                                                                                       |
+| `definitionUrl` or `definition` | ✔        | string  | CORS-enabled URL to, or contents of, OpenAPI v3 document to render. Supports JSON or YAML.                                                                                                                                          |
 | `navSort`                       |          | enum    | This property applies when your definition uses `tags`. Valid values are `alpha` which sorts by HTTP method, then path or `false`, which will display paths as defined. Defaults to `false`.                                        |
 | `validate`                      |          | boolean | If `true`, uses [Mermade](https://openapi-converter.herokuapp.com/) to validate definition. Defaults to `false`.                                                                                                                    |
 | `initialSchemaTreeDepth`        |          | number  | The initial opened tree depth for schema visualiser when first rendered. This is useful when the schema's actual contents is a couple of levels deep, and you want to expand the tree to the contents automatically. Defaults to 0. |
 
 ## Philosophy
 
-While this project is currently focused on visualising Open API V3 specifications, it is architected in such a way that the React components deal with a `UIReadySchema`, which is a generic specification (admittedly heavily based on Open API V3).
+While this project is currently focused on visualising OpenAPI V3 specifications, it is architected in such a way that the React components deal with a `UIReadySchema`, which is a generic specification (admittedly heavily based on OpenAPI V3).
 
 The dream is that this renderer could visualise other formats by introducing new parsers which transform documents into the common `UIReadySchema` format. This approach allows us to build something sustainable and scalable, where the community can help contribute new parsers (among other things!) as required.
 

--- a/docs/open-api-v3-support.md
+++ b/docs/open-api-v3-support.md
@@ -1,28 +1,28 @@
 # Open API v3 support
 
-Tracking: [v3.0.0-rc2][oa3]
+Tracking: [v3.0.0][oa3]
 
 This document outlines this project's support for visualising the [Open API V3][oa3] specification. Content is outlined in the same order as the original specification to make reading as quick (and familiar) as possible.
 
 ## General
 
-### [Data Types](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#dataTypes)
+### [Data Types](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#dataTypes)
 
 - [x] Primitive data types, `integer`, `number`, `string` and `boolean`.
 - [x] Any `format` will be displayed.
 
-### [Rich Text Formatting](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#rich-text-formatting)
+### [Rich Text Formatting](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#rich-text-formatting)
 
 - [x] All `description` fields support [CommonMark][cm].
 
-### [Relative References in URLs](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#relative-references-in-urls)
+### [Relative References in URLs](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#relative-references-in-urls)
 
 - [ ] Relative references are resolved using the URLs defined in the Server Object as a Base URI.
 - [x] Relative references used in `$ref` are processed as per JSON Reference.
 
 ## Schema
 
-### [OpenAPI](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#openapi-object) object
+### [OpenAPI](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#openapi-object) object
 
 - [ ] openapi
 - [x] [info](#info-object)
@@ -33,7 +33,7 @@ This document outlines this project's support for visualising the [Open API V3][
 - [x] [tags](#tag-object)
 - [x] [externalDocs](#external-documentation-object)
 
-### [Info](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#info-object) object
+### [Info](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#info-object) object
 
 - [x] title
 - [x] description
@@ -42,30 +42,30 @@ This document outlines this project's support for visualising the [Open API V3][
 - [x] [license](#license-object)
 - [x] version
 
-### [Contact](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#contact-object)
+### [Contact](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#contact-object)
 
 - [x] name
 - [x] url
 - [x] email
 
-### [License](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#license-object) object
+### [License](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#license-object) object
 
 - [x] name
 - [x] url
 
-### [Server](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#server-object) object
+### [Server](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#server-object) object
 
 - [x] url
 - [x] description
 - [ ] [variables](#server-variable-object)
 
-### [Server Variable](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#server-variable-object) object
+### [Server Variable](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#server-variable-object) object
 
 - [ ] enum
 - [ ] default
 - [ ] description
 
-### [Components](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#components-object) object
+### [Components](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#components-object) object
 
 This is supported by default as all `$ref` are dereferenced before the definition is visualised. As per spec, Components have _no impact_ on visualising the API reference, they are simply a placeholder for reusable objects.
 
@@ -79,11 +79,11 @@ This is supported by default as all `$ref` are dereferenced before the definitio
 - [x] [links](#link-object)
 - [x] [callbacks](#callback-object)
 
-### [Paths](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#paths-object) object
+### [Paths](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#paths-object) object
 
 - [x] [pathItem](#path-item-object)
 
-### [Path Item](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#path-item-object) object
+### [Path Item](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#path-item-object) object
 
 - [x] $ref
 - [x] summary
@@ -99,7 +99,7 @@ This is supported by default as all `$ref` are dereferenced before the definitio
 - [ ] [server](#server-object)
 - [ ] [parameters](#parameter-object)
 
-### [Operation](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#operation-object) object
+### [Operation](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#operation-object) object
 
 - [x] tags
 - [x] summary
@@ -114,12 +114,12 @@ This is supported by default as all `$ref` are dereferenced before the definitio
 - [ ] [security](#security-scheme-object)
 - [ ] [servers](#server-object)
 
-### [External Documentation](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#external-documentation-object) object
+### [External Documentation](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#external-documentation-object) object
 
 - [x] description
 - [x] url
 
-### [Parameter](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#parameter-object) object
+### [Parameter](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#parameter-object) object
 
 - [x] name
 - [x] in
@@ -149,20 +149,20 @@ This is supported by default as all `$ref` are dereferenced before the definitio
 - [ ] examples
 - [ ] content
 
-### [Request Body](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#request-body-object) object
+### [Request Body](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#request-body-object) object
 
 - [x] description
 - [x] [content](#media-type-object)
 - [ ] required
 
-### [Media Type](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#media-type-object) object
+### [Media Type](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#media-type-object) object
 
 - [x] [schema](#schema-object)
 - [x] [example](#example-object)
 - [x] [examples](#example-object)
 - [ ] [encoding](#encoding-object)
 
-### [Encoding](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#encoding-object) object
+### [Encoding](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#encoding-object) object
 
 - [ ] contentType
 - [ ] [headers](#header-object)
@@ -170,29 +170,29 @@ This is supported by default as all `$ref` are dereferenced before the definitio
 - [ ] explode
 - [ ] allowReserved
 
-### [Responses](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#responses-object) object
+### [Responses](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#responses-object) object
 
 - [x] [response](#response-object)
 
-### [Response](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#response-object) object
+### [Response](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#response-object) object
 
 - [x] description
 - [ ] [headers](#header-object)
 - [x] [content](#media-type-object)
 - [ ] [links](#link-object)
 
-### [Callback](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#callback-object) object
+### [Callback](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#callback-object) object
 
 - [ ] [expression](#path-item-object)
 
-### [Example](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#example-object) object
+### [Example](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#example-object) object
 
 - [ ] summary
 - [ ] description
 - [ ] value
 - [ ] externalValue
 
-### [Link](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#link-object) object
+### [Link](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#link-object) object
 
 - [ ] operationRef
 - [ ] operationId
@@ -201,21 +201,21 @@ This is supported by default as all `$ref` are dereferenced before the definitio
 - [ ] description
 - [ ] [server](#server-object)
 
-### [Header](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#header-object) object
+### [Header](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#header-object) object
 
 See [parameter](#parameter-object) object.
 
-### [Tag](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#tag-object) object
+### [Tag](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#tag-object) object
 
 - [x] name
 - [x] description
 - [x] [externalDocs](#external-documentation-object)
 
-### [Reference](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#reference-object) object
+### [Reference](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#reference-object) object
 
 - [x] $ref
 
-### [Schema](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#schema-object) object
+### [Schema](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#schema-object) object
 
 The `Schema` object describes several properties that are shared from JSON Schema, deviations from JSON Schema, or in addition to JSON Schema. The following descibes this project's support for these properties.
 
@@ -267,12 +267,12 @@ The OpenAPI specification also supports several additional properties from JSON 
 - [ ] example
 - [ ] deprecated
 
-### [Discriminator](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#discriminator-object) object
+### [Discriminator](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#discriminator-object) object
 
 - [ ] propertyName
 - [ ] mapping
 
-### [XML](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#xml-object) object
+### [XML](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#xml-object) object
 
 - [ ] name
 - [ ] namespace
@@ -280,7 +280,7 @@ The OpenAPI specification also supports several additional properties from JSON 
 - [ ] attribute
 - [ ] wrapped
 
-### [Security Scheme](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#security-scheme-object) object
+### [Security Scheme](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#security-scheme-object) object
 
 - [x] type
   - [x] apiKey
@@ -295,30 +295,30 @@ The OpenAPI specification also supports several additional properties from JSON 
 - [x] [flows](#oauth-flows-object)
 - [x] openIdConnectUrl
 
-### [OAuth Flows](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#oauth-flows-object) object
+### [OAuth Flows](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#oauth-flows-object) object
 
 - [x] [implict](#oauth-flow-object)
 - [x] [password](#oauth-flow-object)
 - [x] [clientCredentials](#oauth-flow-object)
 - [x] [authorizationCode](#oauth-flow-object)
 
-### [OAuth Flow](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#oauth-flow-object) object
+### [OAuth Flow](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#oauth-flow-object) object
 
 - [x] authorizationUrl
 - [x] tokenUrl
 - [x] refreshUrl
 - [x] scopes
 
-### [Security Requirement](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#security-requirement-object) object
+### [Security Requirement](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#security-requirement-object) object
 
 - [x] oauth2
 - [x] openIdConnect
 - [ ] "other"
 
-### [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.md#specification-extensions)
+### [Specification Extensions](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#specification-extensions)
 
 No extension properties are supported at this time.
 
 [cm]: http://spec.commonmark.org/0.27/
 [jsschema]: http://json-schema.org/latest/json-schema-validation.html#rfc.section.6
-[oa3]: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0-rc2/versions/3.0.md
+[oa3]: https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md

--- a/docs/open-api-v3-support.md
+++ b/docs/open-api-v3-support.md
@@ -1,8 +1,8 @@
-# Open API v3 support
+# OpenAPI v3 support
 
 Tracking: [v3.0.0][oa3]
 
-This document outlines this project's support for visualising the [Open API V3][oa3] specification. Content is outlined in the same order as the original specification to make reading as quick (and familiar) as possible.
+This document outlines this project's support for visualising the [OpenAPI V3][oa3] specification. Content is outlined in the same order as the original specification to make reading as quick (and familiar) as possible.
 
 ## General
 

--- a/src/containers/Base/Base.js
+++ b/src/containers/Base/Base.js
@@ -170,7 +170,7 @@ const Definition = ({ definition, definitionUrl, hash, initialSchemaTreeDepth })
   !definition
     ? <Overlay>
       <img src={lincolnLogo} alt='' />
-      <h3>Render your Open API definition.<br /><br />You can either input a CORS-enabled URL above, or input a definition as text</h3>
+      <h3>Render your OpenAPI document.<br /><br />You can either input a CORS-enabled URL above, or input a definition as text</h3>
       <p>You can also set a url with the <code>?url</code> query parameter.</p>
     </Overlay>
     : <Page definition={definition} hash={hash} definitionUrl={definitionUrl} initialSchemaTreeDepth={initialSchemaTreeDepth} />

--- a/src/parser/open-api/v3/open-api-v3-parser.js
+++ b/src/parser/open-api/v3/open-api-v3-parser.js
@@ -129,7 +129,7 @@ function buildNavigationAndServices (paths, servers, apiSecurity, securityDefini
  * This method mutates the `uiObject` parameter.
  *
  * @param {Object} uiObject
- * @param {Object} mediaType Open API mediaType object
+ * @param {Object} mediaType OpenAPI mediaType object
  */
 function addMediaTypeInfoToUIObject (uiObject, mediaType) {
   if (mediaType.schema) {
@@ -282,7 +282,7 @@ function getUIResponses (responses) {
 /**
  * Extracts the content for UI from the first available media type
  *
- * @param {Object} content Open API v3 Content Object
+ * @param {Object} content OpenAPI v3 Content Object
  * @return {Object|null}
  */
 function getMediaType (content) {

--- a/src/parser/open-api/v3/securityParser.js
+++ b/src/parser/open-api/v3/securityParser.js
@@ -1,5 +1,5 @@
 /**
- * Extracts any security schemes from the given Open API V3 definition file.
+ * Extracts any security schemes from the given OpenAPI V3 definition file.
  * Security schemes are defined in `components.securitySchemes`.
  * The API defines what security applies at either the top level (`security`)
  * or per operation.


### PR DESCRIPTION
OpenAPI v3 is now out 🎉 

This PR:

- Uses `OpenAPI` correctly [as described in the style guide](https://github.com/OAI/OpenAPI-Style-Guide#the-specification-name-and-usage).
- Uses the term 'documents' when loosely describing the specification (per https://github.com/OAI/OpenAPI-Specification/pull/1247)
- Updates broken links to the 3.0.0 spec.