### PR TITLE
Example object rendering is standardised

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ pids
 *.pid
 *.seed
 coverage
+jest_*
 
 # Dependency directories
 node_modules
@@ -19,3 +20,6 @@ dist
 
 # OSX
 .DS_Store
+
+# IntelliJ
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-Nil.
+- Example object rendering is updated to support the summary, description, and value attributes.
 
 ## [v0.2.0] - 2017-09-14
 

--- a/docs/open-api-v3-support.md
+++ b/docs/open-api-v3-support.md
@@ -187,9 +187,9 @@ This is supported by default as all `$ref` are dereferenced before the definitio
 
 ### [Example](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#example-object) object
 
-- [ ] summary
-- [ ] description
-- [ ] value
+- [x] summary
+- [x] description
+- [x] value
 - [ ] externalValue
 
 ### [Link](https://github.com/OAI/OpenAPI-Specification/blob/3.0.0/versions/3.0.0.md#link-object) object

--- a/src/components/Example/Example.js
+++ b/src/components/Example/Example.js
@@ -47,7 +47,7 @@ export default class Example extends Component {
           <div className={classNames(classes.buttons, {
             [classes.hovered]: this.state.hovered
           })}>
-            <CopyButton onCopyClick={this.onCopyClick} tooltip='Copy to Clipboard'/>
+            <CopyButton onCopyClick={this.onCopyClick} tooltip='Copy to Clipboard' />
             {!isJson &&
             <span onClick={() => this.setState({collapseAll: false})}>Expand All</span>}
             {!isJson &&

--- a/src/components/Example/Example.js
+++ b/src/components/Example/Example.js
@@ -27,39 +27,46 @@ export default class Example extends Component {
       example = examples[0]
     }
 
-    const isJson = typeof example !== 'string'
-
     if (!example) {
       return null
     }
 
+    const isJson = typeof example.value !== 'string'
+
     return (
-      <div className={classes.example}
-        onMouseEnter={() => this.setState({ hovered: true })}
-        onMouseLeave={() => this.setState({ hovered: false })}
-      >
-        <div className={classNames(classes.buttons, {
-          [classes.hovered]: this.state.hovered
-        })}>
-          <CopyButton onCopyClick={this.onCopyClick} tooltip='Copy to Clipboard' />
-          {!isJson &&
-            <span onClick={() => this.setState({ collapseAll: false })}>Expand All</span>}
-          {!isJson &&
-            <span onClick={() => this.setState({ collapseAll: true })}>Collapse All</span>}
-        </div>
-        <pre>
-          {
-            isJson
-              ? JSON.stringify(example, null, 2)
-              : example
-          }
-        </pre>
+      <div className={classes.example}>
+        {example.summary &&
+        <div className={classes.summary}>{ example.summary }</div>}
+        {example.description &&
+        <div className={classes.description}>{ example.description }</div>}
+        {example.value &&
+        <div className={classes.value}
+          onMouseEnter={() => this.setState({ hovered: true })}
+          onMouseLeave={() => this.setState({ hovered: false })}
+        >
+          <div className={classNames(classes.buttons, {
+            [classes.hovered]: this.state.hovered
+          })}>
+            <CopyButton onCopyClick={this.onCopyClick} tooltip='Copy to Clipboard'/>
+            {!isJson &&
+            <span onClick={() => this.setState({collapseAll: false})}>Expand All</span>}
+            {!isJson &&
+            <span onClick={() => this.setState({collapseAll: true})}>Collapse All</span>}
+          </div>
+          <pre>
+            {
+              isJson
+                ? JSON.stringify(example.value, null, 2)
+                : example.value
+            }
+          </pre>
+        </div>}
       </div>
     )
   }
 
   onCopyClick () {
-    copy(JSON.stringify(this.props.examples[0], null, 2))
+    copy(JSON.stringify(this.props.examples[0].value, null, 2))
   }
 }
 

--- a/src/components/Example/Example.styles.js
+++ b/src/components/Example/Example.styles.js
@@ -4,13 +4,13 @@ export const styles = createSheet(({ backgrounds, text, sizes }) => ({
   'summary': {
     lineHeight: '1.4',
     fontSize: `${sizes.h4}`,
-    marginBottom: "1rem"
-   },
+    marginBottom: '1rem'
+  },
 
   'description': {
     lineHeight: '1.2',
     fontSize: `${sizes.text}`,
-    marginBottom: "1rem"
+    marginBottom: '1rem'
   },
 
   'value': {

--- a/src/components/Example/Example.styles.js
+++ b/src/components/Example/Example.styles.js
@@ -1,7 +1,19 @@
 import { createSheet } from '../../theme'
 
-export const styles = createSheet(({ backgrounds, text }) => ({
-  'example': {
+export const styles = createSheet(({ backgrounds, text, sizes }) => ({
+  'summary': {
+    lineHeight: '1.4',
+    fontSize: `${sizes.h4}`,
+    marginBottom: "1rem"
+   },
+
+  'description': {
+    lineHeight: '1.2',
+    fontSize: `${sizes.text}`,
+    marginBottom: "1rem"
+  },
+
+  'value': {
     backgroundColor: `${backgrounds.example}`,
     color: `${text.reversed}`,
     padding: '1rem'

--- a/test/components/Example.test.js
+++ b/test/components/Example.test.js
@@ -37,7 +37,7 @@ describe('<Example />', () => {
 
   it('renders a JSON example', () => {
     const tree = renderer.create(
-      <Example examples={[{'value':{'message': 'hi'}}]} />
+      <Example examples={[{'value': {'message': 'hi'}}]} />
     )
 
     expect(tree).toMatchSnapshot()
@@ -53,7 +53,7 @@ describe('<Example />', () => {
 
   it('renders a JSON example with a summary', () => {
     const tree = renderer.create(
-      <Example examples={[{'summary': 'This is a test summary.', 'value':{'message': 'hi'}}]} />
+      <Example examples={[{'summary': 'This is a test summary.', 'value': {'message': 'hi'}}]} />
     )
 
     expect(tree).toMatchSnapshot()
@@ -69,7 +69,7 @@ describe('<Example />', () => {
 
   it('renders a JSON example with a description', () => {
     const tree = renderer.create(
-      <Example examples={[{'description': 'This is a test description.', 'value':{'message': 'hi'}}]} />
+      <Example examples={[{'description': 'This is a test description.', 'value': {'message': 'hi'}}]} />
     )
 
     expect(tree).toMatchSnapshot()
@@ -85,7 +85,7 @@ describe('<Example />', () => {
 
   it('renders a JSON example with a summary and a description', () => {
     const tree = renderer.create(
-      <Example examples={[{'summary': 'This is a test summary.', 'description': 'This is a test description.', 'value':{'message': 'hi'}}]} />
+      <Example examples={[{'summary': 'This is a test summary.', 'description': 'This is a test description.', 'value': {'message': 'hi'}}]} />
     )
 
     expect(tree).toMatchSnapshot()

--- a/test/components/Example.test.js
+++ b/test/components/Example.test.js
@@ -11,9 +11,25 @@ describe('<Example />', () => {
     expect(tree).toMatchSnapshot()
   })
 
+  it('renders the summary only', () => {
+    const tree = renderer.create(
+      <Example examples={[{'summary': 'This is a test summary.'}]} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders the description only', () => {
+    const tree = renderer.create(
+      <Example examples={[{'description': 'This is a test description.'}]} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
   it('renders a string example', () => {
     let tree = renderer.create(
-      <Example examples={['<message>hi</message>']} />
+      <Example examples={[{'value': '<message>hi</message>'}]} />
     )
 
     expect(tree).toMatchSnapshot()
@@ -21,7 +37,55 @@ describe('<Example />', () => {
 
   it('renders a JSON example', () => {
     const tree = renderer.create(
-      <Example examples={[{'message': 'hi'}]} />
+      <Example examples={[{'value':{'message': 'hi'}}]} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders a string example with a summary', () => {
+    let tree = renderer.create(
+      <Example examples={[{'summary': 'This is a test summary.', 'value': '<message>hi</message>'}]} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders a JSON example with a summary', () => {
+    const tree = renderer.create(
+      <Example examples={[{'summary': 'This is a test summary.', 'value':{'message': 'hi'}}]} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders a string example with a description', () => {
+    let tree = renderer.create(
+      <Example examples={[{'description': 'This is a test description.', 'value': '<message>hi</message>'}]} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders a JSON example with a description', () => {
+    const tree = renderer.create(
+      <Example examples={[{'description': 'This is a test description.', 'value':{'message': 'hi'}}]} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders a string example with a summary and a description', () => {
+    let tree = renderer.create(
+      <Example examples={[{'summary': 'This is a test summary.', 'description': 'This is a test description.', 'value': '<message>hi</message>'}]} />
+    )
+
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('renders a JSON example with a summary and a description', () => {
+    const tree = renderer.create(
+      <Example examples={[{'summary': 'This is a test summary.', 'description': 'This is a test description.', 'value':{'message': 'hi'}}]} />
     )
 
     expect(tree).toMatchSnapshot()

--- a/test/components/__snapshots__/Example.test.js.snap
+++ b/test/components/__snapshots__/Example.test.js.snap
@@ -1,60 +1,330 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Example /> renders a JSON example with a summary and a description 1`] = `
+<div
+  className={undefined}
+>
+  <div
+    className={undefined}
+  >
+    This is a test summary.
+  </div>
+  <div
+    className={undefined}
+  >
+    This is a test description.
+  </div>
+  <div
+    className={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className=""
+    >
+      <span
+        onClick={[Function]}
+        onMouseOver={[Function]}
+        title="Copy to Clipboard"
+      >
+        Copy
+      </span>
+    </div>
+    <pre>
+      {
+  "message": "hi"
+}
+    </pre>
+  </div>
+</div>
+`;
+
+exports[`<Example /> renders a string example with a summary and a description 1`] = `
+<div
+  className={undefined}
+>
+  <div
+    className={undefined}
+  >
+    This is a test summary.
+  </div>
+  <div
+    className={undefined}
+  >
+    This is a test description.
+  </div>
+  <div
+    className={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className=""
+    >
+      <span
+        onClick={[Function]}
+        onMouseOver={[Function]}
+        title="Copy to Clipboard"
+      >
+        Copy
+      </span>
+      <span
+        onClick={[Function]}
+      >
+        Expand All
+      </span>
+      <span
+        onClick={[Function]}
+      >
+        Collapse All
+      </span>
+    </div>
+    <pre>
+      &lt;message&gt;hi&lt;/message&gt;
+    </pre>
+  </div>
+</div>
+`;
+
+exports[`<Example /> renders a JSON example with a description 1`] = `
+<div
+  className={undefined}
+>
+  <div
+    className={undefined}
+  >
+    This is a test description.
+  </div>
+  <div
+    className={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className=""
+    >
+      <span
+        onClick={[Function]}
+        onMouseOver={[Function]}
+        title="Copy to Clipboard"
+      >
+        Copy
+      </span>
+    </div>
+    <pre>
+      {
+  "message": "hi"
+}
+    </pre>
+  </div>
+</div>
+`;
+
+exports[`<Example /> renders a string example with a description 1`] = `
+<div
+  className={undefined}
+>
+  <div
+    className={undefined}
+  >
+    This is a test description.
+  </div>
+  <div
+    className={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className=""
+    >
+      <span
+        onClick={[Function]}
+        onMouseOver={[Function]}
+        title="Copy to Clipboard"
+      >
+        Copy
+      </span>
+      <span
+        onClick={[Function]}
+      >
+        Expand All
+      </span>
+      <span
+        onClick={[Function]}
+      >
+        Collapse All
+      </span>
+    </div>
+    <pre>
+      &lt;message&gt;hi&lt;/message&gt;
+    </pre>
+  </div>
+</div>
+`;
+
+exports[`<Example /> renders a JSON example with a summary 1`] = `
+<div
+  className={undefined}
+>
+  <div
+    className={undefined}
+  >
+    This is a test summary.
+  </div>
+  <div
+    className={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className=""
+    >
+      <span
+        onClick={[Function]}
+        onMouseOver={[Function]}
+        title="Copy to Clipboard"
+      >
+        Copy
+      </span>
+    </div>
+    <pre>
+      {
+  "message": "hi"
+}
+    </pre>
+  </div>
+</div>
+`;
+
+exports[`<Example /> renders a string example with a summary 1`] = `
+<div
+  className={undefined}
+>
+  <div
+    className={undefined}
+  >
+    This is a test summary.
+  </div>
+  <div
+    className={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+  >
+    <div
+      className=""
+    >
+      <span
+        onClick={[Function]}
+        onMouseOver={[Function]}
+        title="Copy to Clipboard"
+      >
+        Copy
+      </span>
+      <span
+        onClick={[Function]}
+      >
+        Expand All
+      </span>
+      <span
+        onClick={[Function]}
+      >
+        Collapse All
+      </span>
+    </div>
+    <pre>
+      &lt;message&gt;hi&lt;/message&gt;
+    </pre>
+  </div>
+</div>
+`;
+
 exports[`<Example /> renders a JSON example 1`] = `
 <div
   className={undefined}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
 >
   <div
-    className=""
+    className={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
-    <span
-      onClick={[Function]}
-      onMouseOver={[Function]}
-      title="Copy to Clipboard"
+    <div
+      className=""
     >
-      Copy
-    </span>
-  </div>
-  <pre>
-    {
+      <span
+        onClick={[Function]}
+        onMouseOver={[Function]}
+        title="Copy to Clipboard"
+      >
+        Copy
+      </span>
+    </div>
+    <pre>
+      {
   "message": "hi"
 }
-  </pre>
+    </pre>
+  </div>
 </div>
 `;
 
 exports[`<Example /> renders a string example 1`] = `
 <div
   className={undefined}
-  onMouseEnter={[Function]}
-  onMouseLeave={[Function]}
 >
   <div
-    className=""
+    className={undefined}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
-    <span
-      onClick={[Function]}
-      onMouseOver={[Function]}
-      title="Copy to Clipboard"
+    <div
+      className=""
     >
-      Copy
-    </span>
-    <span
-      onClick={[Function]}
-    >
-      Expand All
-    </span>
-    <span
-      onClick={[Function]}
-    >
-      Collapse All
-    </span>
+      <span
+        onClick={[Function]}
+        onMouseOver={[Function]}
+        title="Copy to Clipboard"
+      >
+        Copy
+      </span>
+      <span
+        onClick={[Function]}
+      >
+        Expand All
+      </span>
+      <span
+        onClick={[Function]}
+      >
+        Collapse All
+      </span>
+    </div>
+    <pre>
+      &lt;message&gt;hi&lt;/message&gt;
+    </pre>
   </div>
-  <pre>
-    &lt;message&gt;hi&lt;/message&gt;
-  </pre>
+</div>
+`;
+
+exports[`<Example /> renders the description only 1`] = `
+<div
+  className={undefined}
+>
+  <div
+    className={undefined}
+  >
+    This is a test description.
+  </div>
+</div>
+`;
+
+exports[`<Example /> renders the summary only 1`] = `
+<div
+  className={undefined}
+>
+  <div
+    className={undefined}
+  >
+    This is a test summary.
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
Issue #197 

The Example object rendering did not follow the OpenAPI 3 standard, the code rendered the complete Example object instead of the `value` attribute's value.

The rendering is now adjusted to follow the standards, also the summary, and the description attributes are supported.
